### PR TITLE
refactor: remove callbacks from decoder

### DIFF
--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -64,10 +64,14 @@ typedef enum {
     COMPRESSION_NONE = 4
 } OmCompression_t;
 
+/// Get the number of bytes per element.
+/// This function will set an error if called for an invalid data type.
+/// It only supports array types.
+uint8_t om_get_bytes_per_element(OmDataType_t data_type, OmError_t* error);
 
-uint8_t om_get_bytes_per_element(OmDataType_t data_type);
-
-/// Get the number of bytes per element after compression
+/// Get the number of bytes per element after compression.
+/// This function will set an error if called for an invalid data type.
+/// It only supports array types.
 uint8_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompression_t compression, OmError_t* error);
 
 /// Divide and round up

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -79,7 +79,7 @@ typedef struct {
     uint64_t bytes_per_element_compressed;
 } OmElementSize_t;
 
-OmError_t om_get_element_size(OmDataType_t data_type, OmCompression_t compression, OmElementSize_t* size);
+OmError_t om_get_element_size(uint8_t data_type, uint8_t compression, OmElementSize_t* size);
 
 /// Divide and round up
 #define divide_rounded_up(dividend,divisor) \

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -101,7 +101,7 @@ static const uint8_t OM_BYTES_PER_ELEMENT[23] = {
 };
 
 /// Get the number of bytes per element after compression
-OmError_t om_get_bytes_per_element_compressed(uint8_t data_type, uint8_t compression, uint8_t* size);
+OmError_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompression_t compression, uint8_t* size);
 
 /// Divide and round up
 #define divide_rounded_up(dividend,divisor) \

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -73,13 +73,35 @@ typedef enum {
     COMPRESSION_NONE = 4
 } OmCompression_t;
 
-/// Used by both the encoder and decoder to store the size of elements
-typedef struct {
-    uint64_t bytes_per_element;
-    uint64_t bytes_per_element_compressed;
-} OmElementSize_t;
+// Lookup table for base element sizes by data type
+static const uint8_t OM_BYTES_PER_ELEMENT[23] = {
+    [DATA_TYPE_NONE] =          0,
+    [DATA_TYPE_INT8] =          1,
+    [DATA_TYPE_UINT8] =         1,
+    [DATA_TYPE_INT16] =         2,
+    [DATA_TYPE_UINT16] =        2,
+    [DATA_TYPE_INT32] =         4,
+    [DATA_TYPE_UINT32] =        4,
+    [DATA_TYPE_INT64] =         8,
+    [DATA_TYPE_UINT64] =        8,
+    [DATA_TYPE_FLOAT] =         4,
+    [DATA_TYPE_DOUBLE] =        8,
+    [DATA_TYPE_STRING] =        0,
+    [DATA_TYPE_INT8_ARRAY] =    1,
+    [DATA_TYPE_UINT8_ARRAY] =   1,
+    [DATA_TYPE_INT16_ARRAY] =   2,
+    [DATA_TYPE_UINT16_ARRAY] =  2,
+    [DATA_TYPE_INT32_ARRAY] =   4,
+    [DATA_TYPE_UINT32_ARRAY] =  4,
+    [DATA_TYPE_INT64_ARRAY] =   8,
+    [DATA_TYPE_UINT64_ARRAY] =  8,
+    [DATA_TYPE_FLOAT_ARRAY] =   4,
+    [DATA_TYPE_DOUBLE_ARRAY] =  8,
+    [DATA_TYPE_STRING_ARRAY] =  0
+};
 
-OmError_t om_get_element_size(uint8_t data_type, uint8_t compression, OmElementSize_t* size);
+/// Get the number of bytes per element after compression
+OmError_t om_get_bytes_per_element_compressed(uint8_t data_type, uint8_t compression, uint8_t* size);
 
 /// Divide and round up
 #define divide_rounded_up(dividend,divisor) \

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -12,15 +12,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-/// The function to convert a single a a sequence of elements and convert data type. Applies scale factor.
-typedef void(*om_compress_copy_callback_t)(uint64_t length, float scale_factor, float add_offset, const void* src, void* dest);
-
-/// compress input, of n-elements to output and return number of compressed byte
-typedef uint64_t(*om_compress_callback_t)(const void* src, uint64_t length, void* dest);
-
-/// Perform a 2d filter operation
-typedef void(*om_compress_filter_callback_t)(const uint64_t length0, const uint64_t length1, void* buffer);
-
 /// Number of look-up-table addresses to individual data chunks that will be compressed.
 /// Effectively only the first address will be stored and the next addresses are delta and fixed-bytes-encoded.
 /// A larger number reduces file size marginally if a lot of chunks are used. However, read performance decreases.

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -73,7 +73,13 @@ typedef enum {
     COMPRESSION_NONE = 4
 } OmCompression_t;
 
+/// Used by both the encoder and decoder to store the size of elements
+typedef struct {
+    uint64_t bytes_per_element;
+    uint64_t bytes_per_element_compressed;
+} OmElementSize_t;
 
+OmError_t om_get_element_size(OmDataType_t data_type, OmCompression_t compression, OmElementSize_t* size);
 
 /// Divide and round up
 #define divide_rounded_up(dividend,divisor) \

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -73,35 +73,11 @@ typedef enum {
     COMPRESSION_NONE = 4
 } OmCompression_t;
 
-// Lookup table for base element sizes by data type
-static const uint8_t OM_BYTES_PER_ELEMENT[23] = {
-    [DATA_TYPE_NONE] =          0,
-    [DATA_TYPE_INT8] =          1,
-    [DATA_TYPE_UINT8] =         1,
-    [DATA_TYPE_INT16] =         2,
-    [DATA_TYPE_UINT16] =        2,
-    [DATA_TYPE_INT32] =         4,
-    [DATA_TYPE_UINT32] =        4,
-    [DATA_TYPE_INT64] =         8,
-    [DATA_TYPE_UINT64] =        8,
-    [DATA_TYPE_FLOAT] =         4,
-    [DATA_TYPE_DOUBLE] =        8,
-    [DATA_TYPE_STRING] =        0,
-    [DATA_TYPE_INT8_ARRAY] =    1,
-    [DATA_TYPE_UINT8_ARRAY] =   1,
-    [DATA_TYPE_INT16_ARRAY] =   2,
-    [DATA_TYPE_UINT16_ARRAY] =  2,
-    [DATA_TYPE_INT32_ARRAY] =   4,
-    [DATA_TYPE_UINT32_ARRAY] =  4,
-    [DATA_TYPE_INT64_ARRAY] =   8,
-    [DATA_TYPE_UINT64_ARRAY] =  8,
-    [DATA_TYPE_FLOAT_ARRAY] =   4,
-    [DATA_TYPE_DOUBLE_ARRAY] =  8,
-    [DATA_TYPE_STRING_ARRAY] =  0
-};
+
+uint8_t om_get_bytes_per_element(OmDataType_t data_type);
 
 /// Get the number of bytes per element after compression
-OmError_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompression_t compression, uint8_t* size);
+uint8_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompression_t compression, OmError_t* error);
 
 /// Divide and round up
 #define divide_rounded_up(dividend,divisor) \

--- a/c/include/om_decoder.h
+++ b/c/include/om_decoder.h
@@ -75,10 +75,10 @@ typedef struct {
     float add_offset;
 
     /// The data type of the data
-    OmDataType_t data_type;
+    uint8_t data_type;
 
     /// The compression type of the data
-    OmCompression_t compression;
+    uint8_t compression;
 
     /// The size of the element and compressed element in bytes.
     /// E.g. Int16 could be used to scale down floats
@@ -104,7 +104,17 @@ typedef struct {
  *
  * @returns Return an om_error_t if the compression or dimension is invalid
  */
-OmError_t om_decoder_init(OmDecoder_t* decoder, const OmVariable_t* variable, uint64_t dimension_count, const uint64_t* read_offset, const uint64_t* read_count, const uint64_t* cube_offset, const uint64_t* cube_dimensions, uint64_t io_size_merge, uint64_t io_size_max);
+OmError_t om_decoder_init(
+    OmDecoder_t* decoder,
+    const OmVariable_t* variable,
+    uint64_t dimension_count,
+    const uint64_t* read_offset,
+    const uint64_t* read_count,
+    const uint64_t* cube_offset,
+    const uint64_t* cube_dimensions,
+    uint64_t io_size_merge,
+    uint64_t io_size_max
+);
 
 //OmError_t OmDecoder_init(OmDecoder_t* decoder, float scalefactor, float add_offset, const OmCompression_t compression, const OmDataType_t data_type, uint64_t dimension_count, const uint64_t* dimensions, const uint64_t* chunks, const uint64_t* read_offset, const uint64_t* read_count, const uint64_t* cube_offset, const uint64_t* cube_dimensions, uint64_t lut_size, uint64_t lut_chunk_element_count, uint64_t lut_start, uint64_t io_size_merge, uint64_t io_size_max);
 

--- a/c/include/om_decoder.h
+++ b/c/include/om_decoder.h
@@ -80,9 +80,11 @@ typedef struct {
     /// The compression type of the data
     uint8_t compression;
 
-    /// The size of the element and compressed element in bytes.
-    /// E.g. Int16 could be used to scale down floats
-    OmElementSize_t element_size;
+    /// The size of the elements in bytes
+    uint8_t bytes_per_element;
+
+    /// The size of the elements in bytes after compression, e.g. Int16 could be used to scale floats
+    uint8_t bytes_per_element_compressed;
 } OmDecoder_t;
 
 /**

--- a/c/include/om_decoder.h
+++ b/c/include/om_decoder.h
@@ -74,17 +74,15 @@ typedef struct {
     /// An offset to convert floats to integers while scaling
     float add_offset;
 
-    /// Number of bytes for a single element of the data type
-    int8_t bytes_per_element;
-
-    /// Number of bytes for a single element in the compressed stream. E.g. Int16 could be used to scale down floats
-    int8_t bytes_per_element_compressed;
-
     /// The data type of the data
     OmDataType_t data_type;
 
     /// The compression type of the data
     OmCompression_t compression;
+
+    /// The size of the element and compressed element in bytes.
+    /// E.g. Int16 could be used to scale down floats
+    OmElementSize_t element_size;
 } OmDecoder_t;
 
 /**

--- a/c/include/om_decoder.h
+++ b/c/include/om_decoder.h
@@ -1,7 +1,7 @@
 /**
  * @file om_decoder.h
  * @brief OmFileDecoder: A component for reading and decompressing data from a compressed file format.
- * 
+ *
  * The OmFileDecoder provides functions and structures for reading chunks of compressed data,
  * decompressing them, and storing the results into a target buffer. It supports various compression
  * schemes and allows reading partial or entire datasets in a chunked manner.
@@ -49,7 +49,7 @@ typedef struct {
 
     /// uint64_t of data chunks in this file. This value is computed in the initialisation.
     uint64_t number_of_chunks;
-    
+
     /// The dimensions of the data array. The last dimension is the "fast" dimension meaning the elements are sequential in memory
     const uint64_t* dimensions;
 
@@ -67,36 +67,33 @@ typedef struct {
 
     /// The offset for each dimension if data is read into a larger array.
     const uint64_t* cube_offset;
-    
-    /// The callback to decompress data
-    om_compress_callback_t decompress_callback;
 
-    /// The filter function for each decompressed block. E.g. a 2D delta coding.
-    om_compress_filter_callback_t decompress_filter_callback;
-
-    /// Copy and scale individual values from a chunk into the output array
-    om_compress_copy_callback_t decompress_copy_callback;
-    
     /// A scalefactor to convert floats to integers
     float scale_factor;
-    
+
     /// An offset to convert floats to integers while scaling
     float add_offset;
 
     /// Number of bytes for a single element of the data type
     int8_t bytes_per_element;
-    
+
     /// Number of bytes for a single element in the compressed stream. E.g. Int16 could be used to scale down floats
     int8_t bytes_per_element_compressed;
+
+    /// The data type of the data
+    OmDataType_t data_type;
+
+    /// The compression type of the data
+    OmCompression_t compression;
 } OmDecoder_t;
 
 /**
  * @brief Initializes the `om_decoder_t` structure with the specified parameters.
- * 
+ *
  * This function sets up the `om_decoder_t` instance, configuring its dimensions, chunk information,
- * reading parameters, LUT (Look-Up Table) properties, and decompression methods. It prepares the 
- * decoder for reading and processing compressed data, managing the scaling and decompression callbacks.
- * 
+ * reading parameters, LUT (Look-Up Table) properties, and decompression methods. It prepares the
+ * decoder for reading and processing compressed data.
+ *
  * @param decoder A pointer to an `om_decoder_t` structure that will be initialized.
  * @param variable A pointer to the data region of the variable to read
  * @param dimension_count The number of dimensions of the data (e.g., 3 for 3D data). All following array must have the some dimension count.
@@ -106,7 +103,7 @@ typedef struct {
  * @param cube_dimensions A pointer to an array specifying the dimensions of the target cube being written to.It can be the same as `read_count` but allows writing into larger arrays..
  * @param io_size_merge The maximum size (in bytes) for merging consecutive IO operations. It helps to optimize read performance by merging small reads.
  * @param io_size_max The maximum size (in bytes) for a single IO operation before it is split. It defines the threshold for splitting large reads.
- * 
+ *
  * @returns Return an om_error_t if the compression or dimension is invalid
  */
 OmError_t om_decoder_init(OmDecoder_t* decoder, const OmVariable_t* variable, uint64_t dimension_count, const uint64_t* read_offset, const uint64_t* read_count, const uint64_t* cube_offset, const uint64_t* cube_dimensions, uint64_t io_size_merge, uint64_t io_size_max);
@@ -115,15 +112,15 @@ OmError_t om_decoder_init(OmDecoder_t* decoder, const OmVariable_t* variable, ui
 
 /**
  * @brief Initializes an `om_decoder_index_read_t` structure for reading chunk indices.
- * 
- * This function calculates the starting and ending chunk indices for reading data based on 
- * the dimensions, chunk sizes, and read parameters provided by the `om_decoder_t` structure. 
- * It determines the range of chunks that need to be processed to fulfill the read request, 
+ *
+ * This function calculates the starting and ending chunk indices for reading data based on
+ * the dimensions, chunk sizes, and read parameters provided by the `om_decoder_t` structure.
+ * It determines the range of chunks that need to be processed to fulfill the read request,
  * setting the appropriate values in the `om_decoder_index_read_t` structure.
- * 
- * @param decoder A pointer to a constant `om_decoder_t` structure containing information 
+ *
+ * @param decoder A pointer to a constant `om_decoder_t` structure containing information
  *                about the data array, chunk sizes, read offsets, and dimensions.
- * @param index_read A pointer to an `om_decoder_index_read_t` structure that will be 
+ * @param index_read A pointer to an `om_decoder_index_read_t` structure that will be
  *                   initialized with the computed chunk index range and other related values.
  */
 void om_decoder_init_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_t *indexRead);
@@ -131,35 +128,35 @@ void om_decoder_init_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_
 
 /**
  * @brief Determines the next range of chunks to be read and updates the `om_decoder_index_read_t` structure.
- * 
+ *
  * This function calculates the next set of chunk indices that need to be read from the data, based on the
- * limits set by the maximum I/O size, alignment, and the logical structure of the data. It updates the 
+ * limits set by the maximum I/O size, alignment, and the logical structure of the data. It updates the
  * `om_decoder_index_read_t` structure to reflect the new range of chunks and the corresponding read parameters.
- * 
+ *
  * @param decoder A pointer to a constant `om_decoder_t` structure containing information about the data array,
  *                chunk sizes, I/O constraints, and other relevant parameters.
  * @param index_read A pointer to an `om_decoder_index_read_t` structure, which will be updated with the next
  *                   range of chunks to read and the corresponding offset and size of the read operation.
- * 
+ *
  * @returns `true` if the next read range was successfully computed and updated in `index_read`.
  *         `false` if there are no more chunks left to read, indicating that the end of the read range has been reached.
- * 
+ *
  */
 bool om_decoder_next_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_t* index_read);
 
 
 /**
  * @brief Initializes an `om_decoder_data_read_t` structure for data reading.
- * 
+ *
  * This function sets the initial state of the `om_decoder_data_read_t` structure,
- * preparing it for subsequent data read operations. It initializes the offset, 
+ * preparing it for subsequent data read operations. It initializes the offset,
  * count, index range, and chunk indices based on the provided index read structure.
- * 
- * @param[out] data_read   A pointer to the `om_decoder_data_read_t` structure that 
- *                         will be initialized. This structure maintains the state 
+ *
+ * @param[out] data_read   A pointer to the `om_decoder_data_read_t` structure that
+ *                         will be initialized. This structure maintains the state
  *                         for reading data chunks.
- * @param[in]  index_read  A pointer to the `om_decoder_index_read_t` structure that 
- *                         contains information about the index range and the initial 
+ * @param[in]  index_read  A pointer to the `om_decoder_index_read_t` structure that
+ *                         contains information about the index range and the initial
  *                         chunk index to be used for reading.
  */
 void om_decoder_init_data_read(OmDecoder_dataRead_t *data_read, const OmDecoder_indexRead_t *index_read);
@@ -167,32 +164,32 @@ void om_decoder_init_data_read(OmDecoder_dataRead_t *data_read, const OmDecoder_
 
 /**
  * @brief Prepares the next data read operation for a given chunk of compressed data.
- * 
+ *
  * This function advances the data reading process by calculating the start and end positions
  * of the next data segment to read based on the provided index data and current state
  * of the `om_decoder_data_read_t` structure. It determines how much data to read from
  * the compressed data source and where the decompressed data should be written.
- * 
+ *
  * The function supports two formats:
  * 1. Version 1 format (non-compressed LUTs, where `lut_chunk_element_count` is 1).
  * 2. Compressed LUT format (Version 3+).
- * 
+ *
  * The function reads from a specified index data and updates the `data_read` structure
  * with the offset and size of the next data block to be read.
- * 
- * @param[in]  decoder           A pointer to the `om_decoder_t` structure, which contains 
- *                               information about the file format, compression settings, 
+ *
+ * @param[in]  decoder           A pointer to the `om_decoder_t` structure, which contains
+ *                               information about the file format, compression settings,
  *                               and LUT (look-up table) characteristics.
- * @param[out] data_read         A pointer to `om_decoder_data_read_t` structure that holds 
- *                               the state of the current data read operation. This structure 
+ * @param[out] data_read         A pointer to `om_decoder_data_read_t` structure that holds
+ *                               the state of the current data read operation. This structure
  *                               is updated to reflect the next segment of data to read.
  * @param[in]  index_data        A pointer to the index data, which provides the compressed
  *                               offset information for each chunk in the LUT.
  * @param[in]  index_data_size   The size of the `index_data` buffer in bytes.
- * 
- * @returns `true` if the next data segment was successfully prepared and ready for reading, 
+ *
+ * @returns `true` if the next data segment was successfully prepared and ready for reading,
  *          `false` if there are no more data segments to read or if the range is exhausted.
- * 
+ *
  * @returns May return an out-of-bounds read error on corrupted data.
  */
 bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t* dataRead, const void* indexData, uint64_t indexDataCount, OmError_t* error);
@@ -200,22 +197,22 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
 
 /**
  * @brief Calculates the size of the buffer required to read a single data chunk.
- * 
- * This function determines the size, in bytes, of the buffer needed to read a single 
- * chunk of data from the compressed file, based on the chunk dimensions and the 
+ *
+ * This function determines the size, in bytes, of the buffer needed to read a single
+ * chunk of data from the compressed file, based on the chunk dimensions and the
  * number of bytes per element after decompression.
- * 
- * The calculation involves multiplying the chunk lengths across all dimensions by 
+ *
+ * The calculation involves multiplying the chunk lengths across all dimensions by
  * the number of bytes required to store a single element in the decompressed form.
- * 
- * @param[in] decoder  A pointer to the `om_decoder_t` structure, which holds the 
- *                     decoder configuration, including chunk sizes for each dimension, 
+ *
+ * @param[in] decoder  A pointer to the `om_decoder_t` structure, which holds the
+ *                     decoder configuration, including chunk sizes for each dimension,
  *                     and the number of bytes per element.
- * 
+ *
  * @returns The size of the buffer required to read a single chunk, in bytes.
- * 
- * @note This buffer size is used to allocate memory when reading data chunks during 
- *       the decoding process, ensuring that there is sufficient space to store the 
+ *
+ * @note This buffer size is used to allocate memory when reading data chunks during
+ *       the decoding process, ensuring that there is sufficient space to store the
  *       decompressed data of a chunk.
  */
 uint64_t om_decoder_read_buffer_size(const OmDecoder_t* decoder);
@@ -223,28 +220,28 @@ uint64_t om_decoder_read_buffer_size(const OmDecoder_t* decoder);
 
 /**
  * @brief Decodes multiple data chunks from compressed input into a target buffer.
- * 
- * This function iteratively decodes a range of chunks from the compressed input data 
- * using the specified decoder configuration. It processes each chunk within the provided 
- * range, decompressing it into a buffer and copying the decompressed data into the 
- * output buffer. The decoding uses an internal function `_om_decoder_decode_chunk` 
+ *
+ * This function iteratively decodes a range of chunks from the compressed input data
+ * using the specified decoder configuration. It processes each chunk within the provided
+ * range, decompressing it into a buffer and copying the decompressed data into the
+ * output buffer. The decoding uses an internal function `_om_decoder_decode_chunk`
  * for each individual chunk.
- * 
- * @param[in]  decoder      A pointer to the `om_decoder_t` structure, which defines 
- *                          the decoder configuration, including dimensions, chunk sizes, 
- *                          and decompression callbacks.
- * @param[in]  chunk        An `om_range_t` structure specifying the range of chunks 
- *                          to decode. The range is defined by `chunk.lowerBound` 
+ *
+ * @param[in]  decoder      A pointer to the `om_decoder_t` structure, which defines
+ *                          the decoder configuration, including dimensions, chunk sizes,
+ *                          data type and compression type.
+ * @param[in]  chunk        An `om_range_t` structure specifying the range of chunks
+ *                          to decode. The range is defined by `chunk.lowerBound`
  *                          (inclusive) and `chunk.upperBound` (exclusive).
- * @param[in]  data         A pointer to the compressed data buffer from which the chunks 
+ * @param[in]  data         A pointer to the compressed data buffer from which the chunks
  *                          are read and decoded.
- * @param[in]  data_size    The size of the `data` buffer, in bytes. This ensures that 
+ * @param[in]  data_size    The size of the `data` buffer, in bytes. This ensures that
  *                          the function does not read beyond the provided data size.
- * @param[out] into         A pointer to the output buffer where the decompressed data 
- *                          will be written. The buffer should have enough space to store 
+ * @param[out] into         A pointer to the output buffer where the decompressed data
+ *                          will be written. The buffer should have enough space to store
  *                          the decompressed output.
- * @param[out] chunkBuffer  A temporary buffer used for storing intermediate decompressed 
- *                          chunk data before copying it into the final output buffer. 
+ * @param[out] chunkBuffer  A temporary buffer used for storing intermediate decompressed
+ *                          chunk data before copying it into the final output buffer.
  *                          Must be sized according to `om_decoder_read_buffer_size`
  * @param[out] error  May return an out-of-bounds read error on corrupted data.
  *

--- a/c/include/om_decoder.h
+++ b/c/include/om_decoder.h
@@ -14,6 +14,7 @@
 
 #include "om_common.h"
 #include "om_variable.h"
+#include "conf.h"
 
 typedef struct {
     uint64_t lowerBound;

--- a/c/include/om_decoder.h
+++ b/c/include/om_decoder.h
@@ -14,7 +14,6 @@
 
 #include "om_common.h"
 #include "om_variable.h"
-#include "conf.h"
 
 typedef struct {
     uint64_t lowerBound;

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -9,6 +9,7 @@
 #define OM_ENCODER_H
 
 #include "om_common.h"
+#include "conf.h"
 
 
 // Encoder struct

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -28,9 +28,11 @@ typedef struct {
     /// The compression type of the data
     uint8_t compression;
 
-    /// The size of the element and compressed element in bytes.
-    /// E.g. Int16 could be used to scale down floats
-    OmElementSize_t element_size;
+    /// The size of the elements in bytes
+    uint8_t bytes_per_element;
+
+    /// The size of the elements in bytes after compression, e.g. Int16 could be used to scale floats
+    uint8_t bytes_per_element_compressed;
 } OmEncoder_t;
 
 /// Initialise the OmEncoder structure with information about the shape of data

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -9,7 +9,6 @@
 #define OM_ENCODER_H
 
 #include "om_common.h"
-#include "conf.h"
 
 
 // Encoder struct

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -16,7 +16,7 @@ typedef struct {
     const uint64_t *dimensions;
     const uint64_t *chunks;
     uint64_t dimension_count;
-    
+
     /// The callback to decompress data
     om_compress_callback_t compress_callback;
 
@@ -25,17 +25,27 @@ typedef struct {
 
     /// Copy and scale individual values from a chunk into the output array
     om_compress_copy_callback_t compress_copy_callback;
-    
+
     float scale_factor;
-    
+
     /// An offset to convert floats to integers while scaling
     float add_offset;
-    
+
     /// Number of bytes for a single element of the data type
     int8_t bytes_per_element;
-    
+
     /// Number of bytes for a single element in the compressed stream. E.g. Int16 could be used to scale down floats
     int8_t bytes_per_element_compressed;
+
+    /// The data type of the data
+    OmDataType_t data_type;
+
+    /// The compression type of the data
+    OmCompression_t compression;
+
+    /// The size of the element and compressed element in bytes.
+    /// E.g. Int16 could be used to scale down floats
+    OmElementSize_t element_size;
 } OmEncoder_t;
 
 /// Initialise the OmEncoder structure with information about the shape of data

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -17,25 +17,10 @@ typedef struct {
     const uint64_t *chunks;
     uint64_t dimension_count;
 
-    /// The callback to decompress data
-    om_compress_callback_t compress_callback;
-
-    /// The filter function for each compressed block. E.g. a 2D delta coding.
-    om_compress_filter_callback_t compress_filter_callback;
-
-    /// Copy and scale individual values from a chunk into the output array
-    om_compress_copy_callback_t compress_copy_callback;
-
     float scale_factor;
 
     /// An offset to convert floats to integers while scaling
     float add_offset;
-
-    /// Number of bytes for a single element of the data type
-    int8_t bytes_per_element;
-
-    /// Number of bytes for a single element in the compressed stream. E.g. Int16 could be used to scale down floats
-    int8_t bytes_per_element_compressed;
 
     /// The data type of the data
     OmDataType_t data_type;

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -37,7 +37,7 @@ typedef struct {
 
 /// Initialise the OmEncoder structure with information about the shape of data
 /// May return an error on invalid compression or data types
-OmError_t om_encoder_init(OmEncoder_t* encoder, float scale_factor, float add_offset, uint8_t compression, uint8_t data_type, const uint64_t* dimensions, const uint64_t* chunks, uint64_t dimension_count);
+OmError_t om_encoder_init(OmEncoder_t* encoder, float scale_factor, float add_offset, OmCompression_t compression, OmDataType_t data_type, const uint64_t* dimensions, const uint64_t* chunks, uint64_t dimension_count);
 
 /// Get the number of chunks that is calculated from dimensions and chunks
 uint64_t om_encoder_count_chunks(const OmEncoder_t* encoder);

--- a/c/include/om_encoder.h
+++ b/c/include/om_encoder.h
@@ -23,10 +23,10 @@ typedef struct {
     float add_offset;
 
     /// The data type of the data
-    OmDataType_t data_type;
+    uint8_t data_type;
 
     /// The compression type of the data
-    OmCompression_t compression;
+    uint8_t compression;
 
     /// The size of the element and compressed element in bytes.
     /// E.g. Int16 could be used to scale down floats
@@ -35,7 +35,7 @@ typedef struct {
 
 /// Initialise the OmEncoder structure with information about the shape of data
 /// May return an error on invalid compression or data types
-OmError_t om_encoder_init(OmEncoder_t* encoder, float scale_factor, float add_offset, OmCompression_t compression, OmDataType_t data_type, const uint64_t* dimensions, const uint64_t* chunks, uint64_t dimension_count);
+OmError_t om_encoder_init(OmEncoder_t* encoder, float scale_factor, float add_offset, uint8_t compression, uint8_t data_type, const uint64_t* dimensions, const uint64_t* chunks, uint64_t dimension_count);
 
 /// Get the number of chunks that is calculated from dimensions and chunks
 uint64_t om_encoder_count_chunks(const OmEncoder_t* encoder);

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -42,8 +42,13 @@ OmError_t om_get_bytes_per_element_compressed(uint8_t data_type, uint8_t compres
             break;
 
         case COMPRESSION_FPX_XOR2D:
-        case COMPRESSION_PFOR_DELTA2D:
+        if (data_type != DATA_TYPE_FLOAT_ARRAY && data_type != DATA_TYPE_DOUBLE_ARRAY) {
+            return ERROR_INVALID_DATA_TYPE;
+        }
             *bytes_per_element_compressed = OM_BYTES_PER_ELEMENT[data_type];
+            break;
+        case COMPRESSION_PFOR_DELTA2D:
+            *bytes_per_element_compressed = OM_BYTES_PER_ELEMENT[data_type];;
             break;
 
         default:

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -10,7 +10,7 @@
 #include "vp4.h"
 #include "fp.h"
 #pragma clang diagnostic ignored "-Wunused-parameter"
-
+#pragma clang diagnostic warning "-Wbad-function-cast"
 
 const char* om_error_string(OmError_t error) {
     switch (error) {
@@ -93,7 +93,8 @@ void om_common_copy_float_to_int16(uint64_t length, float scale_factor, float ad
             ((int16_t *)dst)[i] = INT16_MAX;
         } else {
             float scaled = val * scale_factor + add_offset;
-            ((int16_t *)dst)[i] = (int16_t)fmaxf(INT16_MIN, fminf(INT16_MAX, roundf(scaled)));
+            float clamped = fmaxf(INT16_MIN, fminf(INT16_MAX, roundf(scaled)));
+            ((int16_t *)dst)[i] = (int16_t)clamped;
         }
     }
 }
@@ -105,7 +106,8 @@ void om_common_copy_float_to_int32(uint64_t length, float scale_factor, float ad
             ((int32_t *)dst)[i] = INT32_MAX;
         } else {
             float scaled = val * scale_factor + add_offset;
-            ((int32_t *)dst)[i] = (int32_t)fmaxf((float)INT32_MIN, fminf((float)INT32_MAX, roundf(scaled)));
+            float clamped = fmaxf((float)INT32_MIN, fminf((float)INT32_MAX, roundf(scaled)));
+            ((int32_t *)dst)[i] = (int32_t)clamped;
         }
     }
 }
@@ -117,7 +119,8 @@ void om_common_copy_double_to_int64(uint64_t length, float scale_factor, float a
             ((int64_t *)dst)[i] = INT64_MAX;
         } else {
             double scaled = val * (double)scale_factor + (double)add_offset;
-            ((int64_t *)dst)[i] = (int64_t)fmax((float)INT64_MIN, fmin((float)INT64_MAX, round(scaled)));
+            double clamped = fmax((double)INT64_MIN, fmin((double)INT64_MAX, round(scaled)));
+            ((int64_t *)dst)[i] = (int64_t)clamped;
         }
     }
 }
@@ -129,7 +132,8 @@ void om_common_copy_float_to_int16_log10(uint64_t length, float scale_factor, fl
             ((int16_t *)dst)[i] = INT16_MAX;
         } else {
             float scaled = log10f(1 + val) * scale_factor;
-            ((int16_t *)dst)[i] = (int16_t)fmaxf((float)INT16_MIN, fminf((float)INT16_MAX, roundf(scaled)));
+            float clamped = fmaxf(INT16_MIN, fminf(INT16_MAX, roundf(scaled)));
+            ((int16_t *)dst)[i] = (int16_t)clamped;
         }
     }
 }

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -31,6 +31,61 @@ const char* om_error_string(OmError_t error) {
     return "";
 }
 
+OmError_t om_get_element_size(OmDataType_t data_type, OmCompression_t compression, OmElementSize_t* size) {
+    // Set element sizes based on data type
+    switch (data_type) {
+        case DATA_TYPE_INT8_ARRAY:
+        case DATA_TYPE_UINT8_ARRAY:
+            size->bytes_per_element = 1;
+            size->bytes_per_element_compressed = 1;
+            break;
+
+        case DATA_TYPE_INT16_ARRAY:
+        case DATA_TYPE_UINT16_ARRAY:
+            size->bytes_per_element = 2;
+            size->bytes_per_element_compressed = 2;
+            break;
+
+        case DATA_TYPE_INT32_ARRAY:
+        case DATA_TYPE_UINT32_ARRAY:
+        case DATA_TYPE_FLOAT_ARRAY:
+            size->bytes_per_element = 4;
+            size->bytes_per_element_compressed = 4;
+            break;
+
+        case DATA_TYPE_INT64_ARRAY:
+        case DATA_TYPE_UINT64_ARRAY:
+        case DATA_TYPE_DOUBLE_ARRAY:
+            size->bytes_per_element = 8;
+            size->bytes_per_element_compressed = 8;
+            break;
+
+        default:
+            return ERROR_INVALID_DATA_TYPE;
+    }
+
+    // Adjust compressed size based on compression type
+    switch (compression) {
+        case COMPRESSION_PFOR_DELTA2D_INT16:
+        case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
+            if (data_type != DATA_TYPE_FLOAT_ARRAY) {
+                return ERROR_INVALID_DATA_TYPE;
+            }
+            size->bytes_per_element = 4;
+            size->bytes_per_element_compressed = 2;
+            break;
+
+        case COMPRESSION_FPX_XOR2D:
+        case COMPRESSION_PFOR_DELTA2D:
+            break;
+
+        default:
+            return ERROR_INVALID_COMPRESSION_TYPE;
+    }
+
+    return ERROR_OK;
+}
+
 void om_common_copy_float_to_int16(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst) {
     for (uint64_t i = 0; i < length; ++i) {
         float val = ((float *)src)[i];

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -26,44 +26,11 @@ const char* om_error_string(OmError_t error) {
             return "Not an OM file";
         case ERROR_DEFLATED_SIZE_MISMATCH:
             return "Corrupted data: Deflated size does not match";
-            break;
     }
     return "";
 }
 
-OmError_t om_get_element_size(uint8_t data_type, uint8_t compression, OmElementSize_t* size) {
-    // Set element sizes based on data type
-    switch (data_type) {
-        case DATA_TYPE_INT8_ARRAY:
-        case DATA_TYPE_UINT8_ARRAY:
-            size->bytes_per_element = 1;
-            size->bytes_per_element_compressed = 1;
-            break;
-
-        case DATA_TYPE_INT16_ARRAY:
-        case DATA_TYPE_UINT16_ARRAY:
-            size->bytes_per_element = 2;
-            size->bytes_per_element_compressed = 2;
-            break;
-
-        case DATA_TYPE_INT32_ARRAY:
-        case DATA_TYPE_UINT32_ARRAY:
-        case DATA_TYPE_FLOAT_ARRAY:
-            size->bytes_per_element = 4;
-            size->bytes_per_element_compressed = 4;
-            break;
-
-        case DATA_TYPE_INT64_ARRAY:
-        case DATA_TYPE_UINT64_ARRAY:
-        case DATA_TYPE_DOUBLE_ARRAY:
-            size->bytes_per_element = 8;
-            size->bytes_per_element_compressed = 8;
-            break;
-
-        default:
-            return ERROR_INVALID_DATA_TYPE;
-    }
-
+OmError_t om_get_bytes_per_element_compressed(uint8_t data_type, uint8_t compression, uint8_t* bytes_per_element_compressed) {
     // Adjust compressed size based on compression type
     switch (compression) {
         case COMPRESSION_PFOR_DELTA2D_INT16:
@@ -71,18 +38,17 @@ OmError_t om_get_element_size(uint8_t data_type, uint8_t compression, OmElementS
             if (data_type != DATA_TYPE_FLOAT_ARRAY) {
                 return ERROR_INVALID_DATA_TYPE;
             }
-            size->bytes_per_element = 4;
-            size->bytes_per_element_compressed = 2;
+            *bytes_per_element_compressed = 2;
             break;
 
         case COMPRESSION_FPX_XOR2D:
         case COMPRESSION_PFOR_DELTA2D:
+            *bytes_per_element_compressed = OM_BYTES_PER_ELEMENT[data_type];
             break;
 
         default:
             return ERROR_INVALID_COMPRESSION_TYPE;
     }
-
     return ERROR_OK;
 }
 

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -30,7 +30,7 @@ const char* om_error_string(OmError_t error) {
     return "";
 }
 
-OmError_t om_get_bytes_per_element_compressed(uint8_t data_type, uint8_t compression, uint8_t* bytes_per_element_compressed) {
+OmError_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompression_t compression, uint8_t* bytes_per_element_compressed) {
     // Adjust compressed size based on compression type
     switch (compression) {
         case COMPRESSION_PFOR_DELTA2D_INT16:

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -31,7 +31,7 @@ const char* om_error_string(OmError_t error) {
     return "";
 }
 
-OmError_t om_get_element_size(OmDataType_t data_type, OmCompression_t compression, OmElementSize_t* size) {
+OmError_t om_get_element_size(uint8_t data_type, uint8_t compression, OmElementSize_t* size) {
     // Set element sizes based on data type
     switch (data_type) {
         case DATA_TYPE_INT8_ARRAY:

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -7,6 +7,7 @@
 
 #include "vp4.h"
 #include "fp.h"
+#include "conf.h"
 #include "delta2d.h"
 #include "om_decoder.h"
 
@@ -102,10 +103,10 @@ OmError_t om_decoder_init(
     decoder->io_size_max = io_size_max;
     decoder->data_type = data_type;
     decoder->compression = compression;
-    decoder->bytes_per_element = OM_BYTES_PER_ELEMENT[data_type];
+    decoder->bytes_per_element = om_get_bytes_per_element(data_type);
 
-    uint8_t bytes_per_element_compressed = 0;
-    OmError_t error = om_get_bytes_per_element_compressed(data_type, compression, &bytes_per_element_compressed);
+    OmError_t error = ERROR_OK;
+    uint8_t bytes_per_element_compressed = om_get_bytes_per_element_compressed(data_type, compression, &error);
     decoder->bytes_per_element_compressed = bytes_per_element_compressed;
     return error;
 }

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -11,6 +11,7 @@
 #include "delta2d.h"
 #include "om_decoder.h"
 
+#pragma clang diagnostic error "-Wswitch"
 
 void om_decoder_init_data_read(OmDecoder_dataRead_t *data_read, const OmDecoder_indexRead_t *index_read) {
     data_read->offset = 0;
@@ -103,11 +104,10 @@ OmError_t om_decoder_init(
     decoder->io_size_max = io_size_max;
     decoder->data_type = data_type;
     decoder->compression = compression;
-    decoder->bytes_per_element = om_get_bytes_per_element(data_type);
 
     OmError_t error = ERROR_OK;
-    uint8_t bytes_per_element_compressed = om_get_bytes_per_element_compressed(data_type, compression, &error);
-    decoder->bytes_per_element_compressed = bytes_per_element_compressed;
+    decoder->bytes_per_element = om_get_bytes_per_element(data_type, &error);
+    decoder->bytes_per_element_compressed = om_get_bytes_per_element_compressed(data_type, compression, &error);
     return error;
 }
 

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -111,8 +111,8 @@ OmError_t om_decoder_init(
 }
 
 uint64_t om_decode_decompress(
-    uint8_t data_type,
-    uint8_t compression_type,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
     const void* input,
     uint64_t count,
     void* output,
@@ -186,8 +186,8 @@ uint64_t om_decode_decompress(
 }
 
 void om_decode_filter(
-    uint8_t data_type,
-    uint8_t compression_type,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
     void* data,
     uint64_t length_in_chunk,
     uint64_t length_last,
@@ -245,8 +245,8 @@ void om_decode_filter(
 }
 
 void om_decode_copy(
-    uint8_t data_type,
-    uint8_t compression_type,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
     uint64_t count,
     float scale_factor,
     float add_offset,

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -114,7 +114,7 @@ uint64_t om_decode_decompress(
     const OmDataType_t data_type,
     const OmCompression_t compression_type,
     const void* input,
-    uint64_t length_in_chunk,
+    uint64_t count,
     void* output,
     OmError_t* error
 ) {
@@ -124,7 +124,7 @@ uint64_t om_decode_decompress(
         case COMPRESSION_PFOR_DELTA2D_INT16:
         case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
             if (data_type == DATA_TYPE_FLOAT_ARRAY) {
-                result = p4nzdec128v16((unsigned char*)input, (size_t)length_in_chunk, (uint16_t*)output);
+                result = p4nzdec128v16((unsigned char*)input, (size_t)count, (uint16_t*)output);
             } else {
                 *error = ERROR_INVALID_DATA_TYPE;
             }
@@ -132,10 +132,10 @@ uint64_t om_decode_decompress(
         case COMPRESSION_FPX_XOR2D:
             switch (data_type) {
                 case DATA_TYPE_FLOAT_ARRAY:
-                    result = om_common_decompress_fpxdec32((unsigned char*)input, (size_t)length_in_chunk, (float*)output);
+                    result = om_common_decompress_fpxdec32((unsigned char*)input, (size_t)count, (float*)output);
                     break;
                 case DATA_TYPE_DOUBLE_ARRAY:
-                    result = om_common_decompress_fpxdec64((unsigned char*)input, (size_t)length_in_chunk, (double*)output);
+                    result = om_common_decompress_fpxdec64((unsigned char*)input, (size_t)count, (double*)output);
                     break;
                 default:
                     *error = ERROR_INVALID_DATA_TYPE;
@@ -144,34 +144,34 @@ uint64_t om_decode_decompress(
         case COMPRESSION_PFOR_DELTA2D:
             switch (data_type) {
                 case DATA_TYPE_INT8_ARRAY:
-                    result = p4nzdec8((unsigned char*)input, (size_t)length_in_chunk, (uint8_t*)output);
+                    result = p4nzdec8((unsigned char*)input, (size_t)count, (uint8_t*)output);
                     break;
                 case DATA_TYPE_UINT8_ARRAY:
-                    result = p4nddec8((unsigned char*)input, (size_t)length_in_chunk, (uint8_t*)output);
+                    result = p4nddec8((unsigned char*)input, (size_t)count, (uint8_t*)output);
                     break;
                 case DATA_TYPE_INT16_ARRAY:
-                    result = p4nzdec128v16((unsigned char*)input, (size_t)length_in_chunk, (uint16_t*)output);
+                    result = p4nzdec128v16((unsigned char*)input, (size_t)count, (uint16_t*)output);
                     break;
                 case DATA_TYPE_UINT16_ARRAY:
-                    result = p4nddec128v16((unsigned char*)input, (size_t)length_in_chunk, (uint16_t*)output);
+                    result = p4nddec128v16((unsigned char*)input, (size_t)count, (uint16_t*)output);
                     break;
                 case DATA_TYPE_INT32_ARRAY:
-                    result = p4nzdec128v32((unsigned char*)input, (size_t)length_in_chunk, (uint32_t*)output);
+                    result = p4nzdec128v32((unsigned char*)input, (size_t)count, (uint32_t*)output);
                     break;
                 case DATA_TYPE_UINT32_ARRAY:
-                    result = p4nddec128v32((unsigned char*)input, (size_t)length_in_chunk, (uint32_t*)output);
+                    result = p4nddec128v32((unsigned char*)input, (size_t)count, (uint32_t*)output);
                     break;
                 case DATA_TYPE_INT64_ARRAY:
-                    result = p4nzdec64((unsigned char*)input, (size_t)length_in_chunk, (uint64_t*)output);
+                    result = p4nzdec64((unsigned char*)input, (size_t)count, (uint64_t*)output);
                     break;
                 case DATA_TYPE_UINT64_ARRAY:
-                    result = p4nddec64((unsigned char*)input, (size_t)length_in_chunk, (uint64_t*)output);
+                    result = p4nddec64((unsigned char*)input, (size_t)count, (uint64_t*)output);
                     break;
                 case DATA_TYPE_FLOAT_ARRAY:
-                    result = p4nzdec128v32((unsigned char*)input, (size_t)length_in_chunk, (uint32_t*)output);
+                    result = p4nzdec128v32((unsigned char*)input, (size_t)count, (uint32_t*)output);
                     break;
                 case DATA_TYPE_DOUBLE_ARRAY:
-                    result = p4nzdec64((unsigned char*)input, (size_t)length_in_chunk, (uint64_t*)output);
+                    result = p4nzdec64((unsigned char*)input, (size_t)count, (uint64_t*)output);
                     break;
                 default:
                     *error = ERROR_INVALID_DATA_TYPE;

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -20,15 +20,25 @@ void om_decoder_init_data_read(OmDecoder_dataRead_t *data_read, const OmDecoder_
     data_read->nextChunk = index_read->chunkIndex;
 }
 
-OmError_t om_decoder_init(OmDecoder_t* decoder, const OmVariable_t* variable, uint64_t dimension_count, const uint64_t* read_offset, const uint64_t* read_count, const uint64_t* cube_offset, const uint64_t* cube_dimensions, uint64_t io_size_merge, uint64_t io_size_max) {
-    
+OmError_t om_decoder_init(
+    OmDecoder_t* decoder,
+    const OmVariable_t* variable,
+    uint64_t dimension_count,
+    const uint64_t* read_offset,
+    const uint64_t* read_count,
+    const uint64_t* cube_offset,
+    const uint64_t* cube_dimensions,
+    uint64_t io_size_merge,
+    uint64_t io_size_max
+) {
+
     float scalefactor, add_offset;
     const uint64_t *dimensions, *chunks;
     //uint64_t dimension_count_file;
     OmDataType_t data_type;
     OmCompression_t compression;
     uint64_t lut_size, lut_start, lut_chunk_length;
-    
+
     switch (_om_variable_memory_layout(variable)) {
         case OM_MEMORY_LAYOUT_LEGACY: {
             const OmHeaderV1_t* metaV1 = (const OmHeaderV1_t*)variable;
@@ -63,19 +73,19 @@ OmError_t om_decoder_init(OmDecoder_t* decoder, const OmVariable_t* variable, ui
         case OM_MEMORY_LAYOUT_SCALAR:
             return ERROR_INVALID_DATA_TYPE;
     }
-    
+
     // Calculate the number of chunks based on dims and chunks
     uint64_t nChunks = 1;
     for (uint64_t i = 0; i < dimension_count; i++) {
         nChunks *= divide_rounded_up(dimensions[i], chunks[i]);
     }
-    
+
     // Correctly calculate number of chunks
     if (lut_chunk_length > 0) {
         const uint64_t nLutChunks = divide_rounded_up(nChunks, LUT_CHUNK_COUNT);
         lut_chunk_length = lut_size / nLutChunks;
     }
-    
+
     decoder->number_of_chunks = nChunks;
     decoder->scale_factor = scalefactor;
     decoder->add_offset = add_offset;
@@ -90,161 +100,290 @@ OmError_t om_decoder_init(OmDecoder_t* decoder, const OmVariable_t* variable, ui
     decoder->lut_start = lut_start;
     decoder->io_size_merge = io_size_merge;
     decoder->io_size_max = io_size_max;
-    
+    decoder->data_type = data_type;
+    decoder->compression = compression;
+
     // Set element sizes and copy function
     switch (data_type) {
         case DATA_TYPE_INT8_ARRAY:
         case DATA_TYPE_UINT8_ARRAY:
             decoder->bytes_per_element = 1;
             decoder->bytes_per_element_compressed = 1;
-            decoder->decompress_copy_callback = om_common_copy8;
             break;
-        
+
         case DATA_TYPE_INT16_ARRAY:
         case DATA_TYPE_UINT16_ARRAY:
             decoder->bytes_per_element = 2;
             decoder->bytes_per_element_compressed = 2;
-            decoder->decompress_copy_callback = om_common_copy16;
             break;
-            
+
         case DATA_TYPE_INT32_ARRAY:
         case DATA_TYPE_UINT32_ARRAY:
         case DATA_TYPE_FLOAT_ARRAY:
             decoder->bytes_per_element = 4;
             decoder->bytes_per_element_compressed = 4;
-            decoder->decompress_copy_callback = om_common_copy32;
             break;
-            
+
         case DATA_TYPE_INT64_ARRAY:
         case DATA_TYPE_UINT64_ARRAY:
         case DATA_TYPE_DOUBLE_ARRAY:
             decoder->bytes_per_element = 8;
             decoder->bytes_per_element_compressed = 8;
-            decoder->decompress_copy_callback = om_common_copy32;
             break;
-            
+
         default:
             return ERROR_INVALID_DATA_TYPE;
     }
-    
+
     // TODO more compression and datatypes
     switch (compression) {
         case COMPRESSION_PFOR_DELTA2D_INT16:
-            if (data_type != DATA_TYPE_FLOAT_ARRAY) {
-                return ERROR_INVALID_DATA_TYPE;
-            }
-            decoder->bytes_per_element = 4;
-            decoder->bytes_per_element_compressed = 2;
-            decoder->decompress_copy_callback = om_common_copy_int16_to_float;
-            decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode16;
-            decoder->decompress_callback = (om_compress_callback_t)p4nzdec128v16;
-            break;
-            
-        case COMPRESSION_FPX_XOR2D:
-            switch (data_type) {
-                case DATA_TYPE_FLOAT_ARRAY:
-                    decoder->decompress_callback = om_common_decompress_fpxdec32;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode_xor;
-                    break;
-                    
-                case DATA_TYPE_DOUBLE_ARRAY:
-                    decoder->decompress_callback = om_common_decompress_fpxdec64;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode_xor_double;
-                    break;
-                    
-                default:
-                    return ERROR_INVALID_DATA_TYPE;
-            }
-            break;
-            
-        case COMPRESSION_PFOR_DELTA2D:
-            switch (data_type) {
-                case DATA_TYPE_INT8_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nzdec8;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode8;
-                    break;
-                case DATA_TYPE_UINT8_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nddec8;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode8;
-                    break;
-                case DATA_TYPE_INT16_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nzdec128v16;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode16;
-                    break;
-                case DATA_TYPE_UINT16_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nddec128v16;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode16;
-                    break;
-                case DATA_TYPE_INT32_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nzdec128v32;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode32;
-                    break;
-                case DATA_TYPE_UINT32_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nddec128v32;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode32;
-                    break;
-                case DATA_TYPE_INT64_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nzdec64;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode64;
-                    break;
-                case DATA_TYPE_UINT64_ARRAY:
-                    decoder->decompress_callback = (om_compress_callback_t)p4nddec64;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode64;
-                    break;
-                case DATA_TYPE_FLOAT_ARRAY:
-                    decoder->decompress_copy_callback = om_common_copy_int32_to_float;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode32;
-                    decoder->decompress_callback = (om_compress_callback_t)p4nzdec128v32;
-                    break;
-                case DATA_TYPE_DOUBLE_ARRAY:
-                    decoder->decompress_copy_callback = om_common_copy_int64_to_double;
-                    decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode64;
-                    decoder->decompress_callback = (om_compress_callback_t)p4nzdec64;
-                    break;
-                default:
-                    return ERROR_INVALID_DATA_TYPE;
-            }
-            break;
-            
         case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
             if (data_type != DATA_TYPE_FLOAT_ARRAY) {
                 return ERROR_INVALID_DATA_TYPE;
             }
             decoder->bytes_per_element = 4;
             decoder->bytes_per_element_compressed = 2;
-            decoder->decompress_copy_callback = om_common_copy_int16_to_float_log10;
-            decoder->decompress_filter_callback = (om_compress_filter_callback_t)delta2d_decode16;
-            decoder->decompress_callback = (om_compress_callback_t)p4nzdec128v16;
             break;
-            
+
+        case COMPRESSION_FPX_XOR2D:
+        case COMPRESSION_PFOR_DELTA2D:
+            break;
+
         default:
             return ERROR_INVALID_COMPRESSION_TYPE;
     }
     return ERROR_OK;
 }
 
+uint64_t om_decode_decompress(
+    const OmDataType_t data_type,
+    const OmCompression_t compression_type,
+    const void* input,
+    uint64_t length_in_chunk,
+    void* output,
+    OmError_t* error
+) {
+    uint64_t result = 0;
+
+    switch (compression_type) {
+        case COMPRESSION_PFOR_DELTA2D_INT16:
+        case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
+            if (data_type == DATA_TYPE_FLOAT_ARRAY) {
+                result = p4nzdec128v16((unsigned char*)input, (size_t)length_in_chunk, (uint16_t*)output);
+            } else {
+                *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+        case COMPRESSION_FPX_XOR2D:
+            switch (data_type) {
+                case DATA_TYPE_FLOAT_ARRAY:
+                    result = om_common_decompress_fpxdec32((unsigned char*)input, (size_t)length_in_chunk, (float*)output);
+                    break;
+                case DATA_TYPE_DOUBLE_ARRAY:
+                    result = om_common_decompress_fpxdec64((unsigned char*)input, (size_t)length_in_chunk, (double*)output);
+                    break;
+                default:
+                    *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+        case COMPRESSION_PFOR_DELTA2D:
+            switch (data_type) {
+                case DATA_TYPE_INT8_ARRAY:
+                    result = p4nzdec8((unsigned char*)input, (size_t)length_in_chunk, (uint8_t*)output);
+                    break;
+                case DATA_TYPE_UINT8_ARRAY:
+                    result = p4nddec8((unsigned char*)input, (size_t)length_in_chunk, (uint8_t*)output);
+                    break;
+                case DATA_TYPE_INT16_ARRAY:
+                    result = p4nzdec128v16((unsigned char*)input, (size_t)length_in_chunk, (uint16_t*)output);
+                    break;
+                case DATA_TYPE_UINT16_ARRAY:
+                    result = p4nddec128v16((unsigned char*)input, (size_t)length_in_chunk, (uint16_t*)output);
+                    break;
+                case DATA_TYPE_INT32_ARRAY:
+                    result = p4nzdec128v32((unsigned char*)input, (size_t)length_in_chunk, (uint32_t*)output);
+                    break;
+                case DATA_TYPE_UINT32_ARRAY:
+                    result = p4nddec128v32((unsigned char*)input, (size_t)length_in_chunk, (uint32_t*)output);
+                    break;
+                case DATA_TYPE_INT64_ARRAY:
+                    result = p4nzdec64((unsigned char*)input, (size_t)length_in_chunk, (uint64_t*)output);
+                    break;
+                case DATA_TYPE_UINT64_ARRAY:
+                    result = p4nddec64((unsigned char*)input, (size_t)length_in_chunk, (uint64_t*)output);
+                    break;
+                case DATA_TYPE_FLOAT_ARRAY:
+                    result = p4nzdec128v32((unsigned char*)input, (size_t)length_in_chunk, (uint32_t*)output);
+                    break;
+                case DATA_TYPE_DOUBLE_ARRAY:
+                    result = p4nzdec64((unsigned char*)input, (size_t)length_in_chunk, (uint64_t*)output);
+                    break;
+                default:
+                    *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+
+        default:
+            *error = ERROR_INVALID_COMPRESSION_TYPE;
+    }
+
+    return result;
+}
+
+void om_decode_filter(
+    const OmDataType_t data_type,
+    const OmCompression_t compression_type,
+    void* data,
+    uint64_t length_in_chunk,
+    uint64_t length_last,
+    OmError_t* error
+) {
+    switch (compression_type) {
+        case COMPRESSION_PFOR_DELTA2D_INT16:
+        case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
+            if (data_type == DATA_TYPE_FLOAT_ARRAY) {
+                delta2d_decode16((size_t)(length_in_chunk / length_last), (size_t)length_last, (int16_t*)data);
+            } else {
+                *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+        case COMPRESSION_FPX_XOR2D:
+            switch (data_type) {
+                case DATA_TYPE_FLOAT_ARRAY:
+                    delta2d_decode_xor((size_t)(length_in_chunk / length_last), (size_t)length_last, (float*)data);
+                    break;
+                case DATA_TYPE_DOUBLE_ARRAY:
+                    delta2d_decode_xor_double((size_t)(length_in_chunk / length_last), (size_t)length_last, (double*)data);
+                    break;
+                default:
+                    *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+        case COMPRESSION_PFOR_DELTA2D:
+            switch (data_type) {
+                case DATA_TYPE_INT8_ARRAY:
+                case DATA_TYPE_UINT8_ARRAY:
+                    delta2d_decode8((size_t)(length_in_chunk / length_last), (size_t)length_last, (int8_t*)data);
+                    break;
+                case DATA_TYPE_INT16_ARRAY:
+                case DATA_TYPE_UINT16_ARRAY:
+                    delta2d_decode16((size_t)(length_in_chunk / length_last), (size_t)length_last, (int16_t*)data);
+                    break;
+                case DATA_TYPE_INT32_ARRAY:
+                case DATA_TYPE_UINT32_ARRAY:
+                case DATA_TYPE_FLOAT_ARRAY:
+                    delta2d_decode32((size_t)(length_in_chunk / length_last), (size_t)length_last, (int32_t*)data);
+                    break;
+                case DATA_TYPE_INT64_ARRAY:
+                case DATA_TYPE_UINT64_ARRAY:
+                case DATA_TYPE_DOUBLE_ARRAY:
+                    delta2d_decode64((size_t)(length_in_chunk / length_last), (size_t)length_last, (int64_t*)data);
+                    break;
+                default:
+                    *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+
+        default:
+            *error = ERROR_INVALID_COMPRESSION_TYPE;
+    }
+}
+
+void om_decode_copy(
+    const OmDataType_t data_type,
+    const OmCompression_t compression_type,
+    uint64_t count,
+    float scale_factor,
+    float add_offset,
+    const void* input,
+    void* output,
+    OmError_t* error
+) {
+    switch (compression_type) {
+        case COMPRESSION_PFOR_DELTA2D_INT16:
+            if (data_type == DATA_TYPE_FLOAT_ARRAY) {
+                om_common_copy_int16_to_float(count, scale_factor, add_offset, input, output);
+            } else {
+                *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+
+        case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
+            if (data_type == DATA_TYPE_FLOAT_ARRAY) {
+                om_common_copy_int16_to_float_log10(count, scale_factor, add_offset, input, output);
+            } else {
+                *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+
+        case COMPRESSION_FPX_XOR2D:
+            switch (data_type) {
+                case DATA_TYPE_FLOAT_ARRAY:
+                    om_common_copy32(count, scale_factor, add_offset, input, output);
+                    break;
+                case DATA_TYPE_DOUBLE_ARRAY:
+                    om_common_copy64(count, scale_factor, add_offset, input, output);
+                    break;
+                default:
+                    *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+        case COMPRESSION_PFOR_DELTA2D:
+            switch (data_type) {
+                case DATA_TYPE_INT8_ARRAY:
+                case DATA_TYPE_UINT8_ARRAY:
+                    om_common_copy8(count, scale_factor, add_offset, input, output);
+                    break;
+                case DATA_TYPE_INT16_ARRAY:
+                case DATA_TYPE_UINT16_ARRAY:
+                    om_common_copy16(count, scale_factor, add_offset, input, output);
+                    break;
+                case DATA_TYPE_INT32_ARRAY:
+                case DATA_TYPE_UINT32_ARRAY:
+                    om_common_copy32(count, scale_factor, add_offset, input, output);
+                    break;
+                case DATA_TYPE_FLOAT_ARRAY:
+                    om_common_copy_int32_to_float(count, scale_factor, add_offset, input, output);
+                    break;
+                case DATA_TYPE_INT64_ARRAY:
+                case DATA_TYPE_UINT64_ARRAY:
+                    om_common_copy32(count, scale_factor, add_offset, input, output);
+                    break;
+                case DATA_TYPE_DOUBLE_ARRAY:
+                    om_common_copy_int64_to_double(count, scale_factor, add_offset, input, output);
+                    break;
+                default:
+                    *error = ERROR_INVALID_DATA_TYPE;
+            }
+            break;
+        default:
+            *error = ERROR_INVALID_COMPRESSION_TYPE;
+    }
+}
+
 void om_decoder_init_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_t *index_read) {
     uint64_t chunkStart = 0;
     uint64_t chunkEnd = 1;
-    
+
     for (uint64_t i = 0; i < decoder->dimensions_count; i++) {
         const uint64_t dimension = decoder->dimensions[i];
         const uint64_t chunk = decoder->chunks[i];
         const uint64_t read_offset = decoder->read_offset[i];
         const uint64_t read_count = decoder->read_count[i];
         //printf("dimension=%llu chunk=%llu read_offset=%llu read_count=%llu\n", dimension,chunk,read_offset,read_count);
-        
+
         // Calculate lower and upper chunk indices for the current dimension
         const uint64_t chunkInThisDimensionLower = read_offset / chunk;
         const uint64_t chunkInThisDimensionUpper = divide_rounded_up(read_offset + read_count, chunk);
         const uint64_t chunkInThisDimensionCount = chunkInThisDimensionUpper - chunkInThisDimensionLower;
-        
+
         const uint64_t firstChunkInThisDimension = chunkInThisDimensionLower;
         const uint64_t nChunksInThisDimension = divide_rounded_up(dimension, chunk);
-        
+
         // Update chunkStart and chunkEnd
         chunkStart = chunkStart * nChunksInThisDimension + firstChunkInThisDimension;
-        
+
         if (read_count == dimension) {
             // The entire dimension is read
             chunkEnd = chunkEnd * nChunksInThisDimension;
@@ -273,37 +412,37 @@ uint64_t om_decoder_read_buffer_size(const OmDecoder_t* decoder) {
 
 bool _om_decoder_next_chunk_position(const OmDecoder_t *decoder, OmRange_t *chunk_index) {
     uint64_t rollingMultiply = 1;
-    
+
     // Number of consecutive chunks that can be read linearly.
     uint64_t linearReadCount = 1;
     bool linearRead = true;
     const uint64_t dimensions_count = decoder->dimensions_count;
-    
+
     for (uint64_t i_forward = 0; i_forward < dimensions_count; i_forward++) {
         const uint64_t i = dimensions_count - i_forward - 1;
         const uint64_t dimension = decoder->dimensions[i];
         const uint64_t chunk = decoder->chunks[i];
         const uint64_t read_offset = decoder->read_offset[i];
         const uint64_t read_count = decoder->read_count[i];
-        
+
         // Number of chunks in this dimension.
         const uint64_t nChunksInThisDimension = divide_rounded_up(dimension, chunk);
-        
+
         // Calculate chunk range in this dimension.
         const uint64_t chunkInThisDimensionLower = read_offset / chunk;
         const uint64_t chunkInThisDimensionUpper = divide_rounded_up(read_offset + read_count, chunk);
         const uint64_t chunkInThisDimensionCount = chunkInThisDimensionUpper - chunkInThisDimensionLower;
-        
+
         // Move forward by one.
         chunk_index->lowerBound += rollingMultiply;
-        
+
         // Check for linear read conditions.
         if (i == dimensions_count - 1 && dimension != read_count) {
             // If the fast dimension is only partially read.
             linearReadCount = chunkInThisDimensionCount;
             linearRead = false;
         }
-        
+
         if (linearRead && dimension == read_count) {
             // The dimension is read entirely.
             linearReadCount *= nChunksInThisDimension;
@@ -311,28 +450,28 @@ bool _om_decoder_next_chunk_position(const OmDecoder_t *decoder, OmRange_t *chun
             // Dimension is read partly; cannot merge further reads.
             linearRead = false;
         }
-        
+
         // Calculate the chunk index in this dimension.
         uint64_t c0 = (chunk_index->lowerBound / rollingMultiply) % nChunksInThisDimension;
-        
+
         // Check for overflow.
         if (c0 != chunkInThisDimensionUpper && c0 != 0) {
             break; // No overflow in this dimension, break.
         }
-        
+
         // Adjust chunkIndex.lowerBound if there is an overflow.
         chunk_index->lowerBound -= chunkInThisDimensionCount * rollingMultiply;
-        
+
         // Update the rolling multiplier for the next dimension.
         rollingMultiply *= nChunksInThisDimension;
-        
+
         // If we're at the first dimension and have processed all chunks.
         if (i == 0) {
             chunk_index->upperBound = chunk_index->lowerBound;
             return false;
         }
     }
-    
+
     // Update chunkIndex.upperBound based on the number of chunks that can be read linearly.
     chunk_index->upperBound = chunk_index->lowerBound + linearReadCount;
     return true;
@@ -342,27 +481,27 @@ bool om_decoder_next_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_
     if (index_read->nextChunk.lowerBound >= index_read->nextChunk.upperBound) {
         return false;
     }
-    
+
     index_read->chunkIndex = index_read->nextChunk;
     index_read->indexRange.lowerBound = index_read->nextChunk.lowerBound;
-    
+
     uint64_t chunkIndex = index_read->nextChunk.lowerBound;
-    
+
     const bool isV3LUT = decoder->lut_chunk_length > 1;
     const uint64_t lut_chunk_element_count = isV3LUT ? LUT_CHUNK_COUNT : 1;
     const uint64_t lut_chunk_length = isV3LUT ? decoder->lut_chunk_length : sizeof(uint64_t);
     const uint64_t io_size_max = decoder->io_size_max;
-    
+
     const uint64_t alignOffset = isV3LUT || index_read->indexRange.lowerBound == 0 ? 0 : 1;
     const uint64_t endAlignOffset = isV3LUT ? 1 : 0;
-    
+
     const uint64_t readStart = (index_read->nextChunk.lowerBound - alignOffset) / lut_chunk_element_count * lut_chunk_length;
-    
+
     while (1) {
         const uint64_t maxRead = io_size_max / lut_chunk_length * lut_chunk_element_count;
         const uint64_t nextChunkCount = index_read->nextChunk.upperBound - index_read->nextChunk.lowerBound;
         const uint64_t nextIncrement = max(1, min(maxRead-1, nextChunkCount - 1));
-        
+
         if (index_read->nextChunk.lowerBound + nextIncrement >= index_read->nextChunk.upperBound) {
             if (!_om_decoder_next_chunk_position(decoder, &index_read->nextChunk)) {
                 break;
@@ -370,7 +509,7 @@ bool om_decoder_next_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_
             const uint64_t readEndNext = (index_read->nextChunk.lowerBound + endAlignOffset) / lut_chunk_element_count * lut_chunk_length;
             const uint64_t readStartNext = readEndNext - lut_chunk_length;
             const uint64_t readEndPrevious = chunkIndex / lut_chunk_element_count * lut_chunk_length;
-            
+
             if (readEndNext - readStart > io_size_max) {
                 break;
             }
@@ -379,7 +518,7 @@ bool om_decoder_next_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_
             }
         } else {
             const uint64_t readEndNext = (index_read->nextChunk.lowerBound + nextIncrement + endAlignOffset) / lut_chunk_element_count * lut_chunk_length;
-            
+
             if (readEndNext - readStart > io_size_max) {
                 index_read->nextChunk.lowerBound += 1;
                 break;
@@ -388,11 +527,11 @@ bool om_decoder_next_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_
         }
         chunkIndex = index_read->nextChunk.lowerBound;
     }
-    
+
     const uint64_t readEnd = ((chunkIndex + endAlignOffset) / lut_chunk_element_count + 1) * lut_chunk_length;
     //uint64_t lutTotalSize = divide_rounded_up(decoder->number_of_chunks, decoder->lut_chunk_element_count) * lut_chunk_length;
     //assert(readEnd <= lutTotalSize);
-    
+
     index_read->offset = decoder->lut_start + readStart;
     index_read->count = readEnd - readStart;
     index_read->indexRange.upperBound = chunkIndex + 1;
@@ -403,29 +542,29 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
     if (data_read->nextChunk.lowerBound >= data_read->nextChunk.upperBound) {
         return false;
     }
-    
+
     uint64_t chunkIndex = data_read->nextChunk.lowerBound;
     data_read->chunkIndex.lowerBound = chunkIndex;
-    
+
     // Version 1 case
     if (decoder->lut_chunk_length == 0) {
         // index is a flat Int64 array
         const uint64_t* data = (const uint64_t*)index_data;
-        
+
         const bool isOffset0 = (data_read->indexRange.lowerBound == 0);
         const uint64_t startOffset = isOffset0 ? 1 : 0;
-        
-        
+
+
         uint64_t readPos = chunkIndex - data_read->indexRange.lowerBound - startOffset;
         //printf("chunkIndex %llu lowerBound %llu readPos %llu \n", chunkIndex, data_read->indexRange.lowerBound, readPos);
         if (!isOffset0 && (readPos + 1) * sizeof(int64_t) > index_data_size) {
             (*error) = ERROR_OUT_OF_BOUND_READ;
             return false;
         }
-        
+
         const uint64_t startPos = isOffset0 && chunkIndex == 0 ? 0 : data[readPos];
         uint64_t endPos = startPos;
-        
+
         // Loop to the next chunk until the end is reached
         while (true) {
             readPos = data_read->nextChunk.lowerBound - data_read->indexRange.lowerBound - startOffset + 1;
@@ -434,14 +573,14 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
                 return false;
             }
             const uint64_t dataEndPos = data[readPos];
-            
+
             // Merge and split IO requests, ensuring at least one IO request is sent
             if (startPos != endPos && (dataEndPos - startPos > decoder->io_size_max || dataEndPos - endPos > decoder->io_size_merge)) {
                 break;
             }
             endPos = dataEndPos;
             chunkIndex = data_read->nextChunk.lowerBound;
-            
+
             if (data_read->nextChunk.lowerBound + 1 >= data_read->nextChunk.upperBound) {
                 if (!_om_decoder_next_chunk_position(decoder, &data_read->nextChunk)) {
                     // No next chunk, finish processing the current one and stop
@@ -450,37 +589,37 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
             } else {
                 data_read->nextChunk.lowerBound += 1;
             }
-            
+
             if (data_read->nextChunk.lowerBound >= data_read->indexRange.upperBound) {
                 data_read->nextChunk.lowerBound = 0;
                 data_read->nextChunk.upperBound = 0;
                 break;
             }
         }
-        
+
         // Old files do not compress LUT and data is after LUT
         // V1 header size
         const uint64_t om_header_v1_length = sizeof(OmHeaderV1_t);
         const uint64_t dataStart = om_header_v1_length + decoder->number_of_chunks * sizeof(int64_t);
-        
+
         data_read->offset = startPos + dataStart;
         data_read->count = endPos - startPos;
         data_read->chunkIndex.upperBound = chunkIndex + 1;
         return true;
     }
-    
+
     uint8_t* indexDataPtr = (uint8_t*)index_data;
-    
+
     uint64_t uncompressedLut[LUT_CHUNK_COUNT] = {0};
-    
+
     // Which LUT chunk is currently loaded into `uncompressedLut`
     uint64_t lutChunk = chunkIndex / LUT_CHUNK_COUNT;
-    
+
     const uint64_t lutChunkLength = decoder->lut_chunk_length;
-    
+
     // Offset byte in LUT relative to the index range
     const uint64_t lutOffset = data_read->indexRange.lowerBound / LUT_CHUNK_COUNT * lutChunkLength;
-    
+
     // Uncompress the first LUT index chunk and check the length
     {
         const uint64_t thisLutChunkElementCount = min((lutChunk + 1) * LUT_CHUNK_COUNT, decoder->number_of_chunks+1) - lutChunk * LUT_CHUNK_COUNT;
@@ -489,19 +628,19 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
             (*error) = ERROR_OUT_OF_BOUND_READ;
             return false;
         }
-        
+
         // Decompress LUT chunk
         p4nddec64(indexDataPtr + start, thisLutChunkElementCount, uncompressedLut);
     }
-    
+
     // Index data relative to start index
     const uint64_t startPos = uncompressedLut[chunkIndex % LUT_CHUNK_COUNT];
     uint64_t endPos = startPos;
-    
+
     // Loop to the next chunk until the end is reached
     while (true) {
         const uint64_t nextLutChunk = (data_read->nextChunk.lowerBound + 1) / LUT_CHUNK_COUNT;
-        
+
         // Maybe the next LUT chunk needs to be uncompressed
         if (nextLutChunk != lutChunk) {
             const uint64_t nextLutChunkElementCount = min((nextLutChunk + 1) * LUT_CHUNK_COUNT, decoder->number_of_chunks+1) - nextLutChunk * LUT_CHUNK_COUNT;
@@ -510,21 +649,21 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
                 (*error) = ERROR_OUT_OF_BOUND_READ;
                 return false;
             }
-            
+
             // Decompress LUT chunk
             p4nddec64(indexDataPtr + start, nextLutChunkElementCount, uncompressedLut);
             lutChunk = nextLutChunk;
         }
-        
+
         const uint64_t dataEndPos = uncompressedLut[(data_read->nextChunk.lowerBound + 1) % LUT_CHUNK_COUNT];
-        
+
         // Merge and split IO requests, ensuring at least one IO request is sent
         if (startPos != endPos && (dataEndPos - startPos > decoder->io_size_max || dataEndPos - endPos > decoder->io_size_merge)) {
             break;
         }
         endPos = dataEndPos;
         chunkIndex = data_read->nextChunk.lowerBound;
-        
+
         if (chunkIndex + 1 >= data_read->nextChunk.upperBound) {
             if (!_om_decoder_next_chunk_position(decoder, &data_read->nextChunk)) {
                 // No next chunk, finish processing the current one and stop
@@ -533,14 +672,14 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
         } else {
             data_read->nextChunk.lowerBound += 1;
         }
-        
+
         if (data_read->nextChunk.lowerBound >= data_read->indexRange.upperBound) {
             data_read->nextChunk.lowerBound = 0;
             data_read->nextChunk.upperBound = 0;
             break;
         }
     }
-    
+
     data_read->offset = (uint64_t)startPos;
     data_read->count = (uint64_t)endPos - (uint64_t)startPos;
     data_read->chunkIndex.upperBound = chunkIndex + 1;
@@ -552,18 +691,18 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
     uint64_t rollingMultiply = 1;
     uint64_t rollingMultiplyChunkLength = 1;
     uint64_t rollingMultiplyTargetCube = 1;
-    
+
     int64_t d = 0; // Read coordinate.
     int64_t q = 0; // Write coordinate.
     int64_t linearReadCount = 1;
     bool linearRead = true;
     int64_t lengthLast = 0;
     bool no_data = false;
-    
+
     const uint64_t dimensions_count = decoder->dimensions_count;
-    
+
     //printf("decode dimcount=%d \n", decoder->dims_count );
-    
+
     // Count length in chunk and find first buffer offset position.
     for (uint64_t i_forward = 0; i_forward < dimensions_count; i_forward++) {
         const uint64_t i = dimensions_count - i_forward - 1;
@@ -573,7 +712,7 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
         const uint64_t read_count = decoder->read_count[i];
         const uint64_t cube_offset = decoder->cube_offset[i];
         const uint64_t cube_dimension = decoder->cube_dimensions[i];
-        
+
         const uint64_t nChunksInThisDimension = divide_rounded_up(dimension, chunk);
         const uint64_t c0 = (chunkIndex / rollingMultiply) % nChunksInThisDimension;
         const uint64_t chunkGlobal0Start = c0 * chunk;
@@ -583,28 +722,28 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
         const uint64_t clampedGlobal0End = min(chunkGlobal0End, read_offset + read_count);
         const uint64_t clampedLocal0Start = clampedGlobal0Start - c0 * chunk;
         const uint64_t lengthRead = clampedGlobal0End - clampedGlobal0Start;
-        
+
         if (read_offset + read_count <= chunkGlobal0Start || read_offset >= chunkGlobal0End) {
             no_data = true;
         }
-        
+
         if (i == dimensions_count - 1) {
             lengthLast = length0;
         }
-        
+
         const uint64_t d0 = clampedLocal0Start;
         const uint64_t t0 = chunkGlobal0Start - read_offset + d0;
         const uint64_t q0 = t0 + cube_offset;
-        
+
         d += rollingMultiplyChunkLength * d0;
         q += rollingMultiplyTargetCube * q0;
-        
+
         if (i == dimensions_count - 1 && !(lengthRead == length0 && read_count == length0 && cube_dimension == length0)) {
             // if fast dimension and only partially read
             linearReadCount = lengthRead;
             linearRead = false;
         }
-        
+
         if (linearRead && lengthRead == length0 && read_count == length0 && cube_dimension == length0) {
             // dimension is read entirely
             // and can be copied linearly into the output buffer
@@ -613,30 +752,58 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
             // dimension is read partly, cannot merge further reads
             linearRead = false;
         }
-        
+
         rollingMultiply *= nChunksInThisDimension;
         rollingMultiplyTargetCube *= cube_dimension;
         rollingMultiplyChunkLength *= length0;
     }
-    
+
     const uint64_t lengthInChunk = rollingMultiplyChunkLength;
-    const uint64_t uncompressedBytes = (*decoder->decompress_callback)(data, lengthInChunk, chunk_buffer);
-    
+
+    OmError_t error = ERROR_OK;
+    const uint64_t uncompressedBytes = om_decode_decompress(
+        decoder->data_type,
+        decoder->compression,
+        data,
+        lengthInChunk,
+        chunk_buffer,
+        &error
+    );
+
+    if (error != ERROR_OK) {
+        printf("Error in om_decode_decompress %d\n", error);
+        return 0;
+    }
+
     if (no_data) {
         return uncompressedBytes;
     }
-    
-    /// Perform 2D decoding
-    (*decoder->decompress_filter_callback)(lengthInChunk / lengthLast, lengthLast, chunk_buffer);
-    
+
+    // Perform 2D decoding
+    om_decode_filter(decoder->data_type, decoder->compression, chunk_buffer, lengthInChunk, lengthLast, &error);
+
+    if (error != ERROR_OK) {
+        printf("Error in om_decode_filter %d\n", error);
+        return 0;
+    }
+
     // Copy data from the chunk buffer to the output buffer.
     while (true) {
-        /// Copy values from chunk buffer into output buffer
-        (*decoder->decompress_copy_callback)(linearReadCount, decoder->scale_factor, decoder->add_offset, &chunk_buffer[d * decoder->bytes_per_element_compressed], &into[q * decoder->bytes_per_element]);
-        
+        // Copy values from chunk buffer into output buffer
+        om_decode_copy(
+            decoder->data_type,
+            decoder->compression,
+            linearReadCount,
+            decoder->scale_factor,
+            decoder->add_offset,
+            &chunk_buffer[d * decoder->bytes_per_element_compressed],
+            &into[q * decoder->bytes_per_element],
+            &error
+        );
+
         q += linearReadCount - 1;
         d += linearReadCount - 1;
-        
+
         rollingMultiply = 1;
         rollingMultiplyTargetCube = 1;
         rollingMultiplyChunkLength = 1;
@@ -649,7 +816,7 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
             const uint64_t read_offset = decoder->read_offset[i];
             const uint64_t read_count = decoder->read_count[i];
             const uint64_t cube_dimension = decoder->cube_dimensions[i];
-            
+
             //printf("i=%d q=%d d=%d\n", i,q,d);
             const uint64_t nChunksInThisDimension = divide_rounded_up(dimension, chunk);
             const uint64_t c0 = (chunkIndex / rollingMultiply) % nChunksInThisDimension;
@@ -660,10 +827,10 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
             const uint64_t clampedGlobal0End = min(chunkGlobal0End, read_offset + read_count);
             const uint64_t clampedLocal0End = clampedGlobal0End - chunkGlobal0Start;
             const uint64_t lengthRead = clampedGlobal0End - clampedGlobal0Start;
-            
+
             d += rollingMultiplyChunkLength;
             q += rollingMultiplyTargetCube;
-            
+
             if ((i == dimensions_count - 1) && !(lengthRead == length0 && read_count == length0 && cube_dimension == length0)) {
                 // if fast dimension and only partially read
                 linearReadCount = lengthRead;
@@ -677,35 +844,33 @@ uint64_t _om_decoder_decode_chunk(const OmDecoder_t *decoder, uint64_t chunkInde
                 // dimension is read partly, cannot merge further reads
                 linearRead = false;
             }
-            
+
             const uint64_t d0 = (d / rollingMultiplyChunkLength) % length0;
             if (d0 != clampedLocal0End && d0 != 0) {
                 //printf("break\n");
                 break; // No overflow in this dimension, break
             }
-            
+
             d -= lengthRead * rollingMultiplyChunkLength;
             q -= lengthRead * rollingMultiplyTargetCube;
-            
+
             rollingMultiply *= nChunksInThisDimension;
             rollingMultiplyTargetCube *= cube_dimension;
             rollingMultiplyChunkLength *= length0;
             //printf("next iter\n");
             if (i == 0) {
-                //printf("return\n");
                 return uncompressedBytes; // All chunks have been read. End of iteration
             }
         }
     }
-    
     return uncompressedBytes;
 }
 
 bool om_decoder_decode_chunks(const OmDecoder_t *decoder, OmRange_t chunk, const void *data, uint64_t data_size, void *into, void *chunkBuffer, OmError_t* error) {
     uint64_t pos = 0;
-    //printf("chunkIndex.lowerBound %llu %llu\n",chunk.lowerBound,chunk.upperBound);
+    // printf("chunkIndex.lowerBound %lu %lu\n",chunk.lowerBound,chunk.upperBound);
     for (uint64_t chunkNum = chunk.lowerBound; chunkNum < chunk.upperBound; ++chunkNum) {
-        //printf("chunkIndex %llu pos=%llu dataCount=%llu \n",chunkNum, pos, data_size);
+        // printf("chunkIndex %lu pos=%lu dataCount=%lu \n",chunkNum, pos, data_size);
         if (pos >= data_size) {
             (*error) = ERROR_DEFLATED_SIZE_MISMATCH;
             return false;
@@ -713,8 +878,8 @@ bool om_decoder_decode_chunks(const OmDecoder_t *decoder, OmRange_t chunk, const
         uint64_t uncompressedBytes = _om_decoder_decode_chunk(decoder, chunkNum, (const uint8_t *)data + pos, into, chunkBuffer);
         pos += uncompressedBytes;
     }
-    //printf("%llu %llu \n", pos, data_size);
-    
+    // printf("%lu %lu \n", pos, data_size);
+
     if (pos != data_size) {
         (*error) = ERROR_DEFLATED_SIZE_MISMATCH;
         return false;

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -34,9 +34,8 @@ OmError_t om_decoder_init(
 
     float scalefactor, add_offset;
     const uint64_t *dimensions, *chunks;
-    //uint64_t dimension_count_file;
-    OmDataType_t data_type;
-    OmCompression_t compression;
+    uint8_t data_type;
+    uint8_t compression;
     OmElementSize_t element_size;
     uint64_t lut_size, lut_start, lut_chunk_length;
 
@@ -45,16 +44,17 @@ OmError_t om_decoder_init(
             const OmHeaderV1_t* metaV1 = (const OmHeaderV1_t*)variable;
             scalefactor = metaV1->scale_factor;
             add_offset = 0;
-            //dimension_count_file = 2;
             data_type = DATA_TYPE_FLOAT_ARRAY;
-            compression = (OmCompression_t)metaV1->compression_type;
+            compression = metaV1->compression_type;
             if (metaV1->version == 1) {
                 compression = COMPRESSION_PFOR_DELTA2D_INT16;
             }
             lut_chunk_length = 0;
             lut_start = 40; // Right after header
             lut_size = 0; // ignored
+            // dim1 follows dim0 in header, thus this pointer is correct
             dimensions = &metaV1->dim0;
+            // chunk1 follows chunk0 in header, thus this pointer is correct
             chunks = &metaV1->chunk0;
             break;
         }
@@ -111,8 +111,8 @@ OmError_t om_decoder_init(
 }
 
 uint64_t om_decode_decompress(
-    const OmDataType_t data_type,
-    const OmCompression_t compression_type,
+    uint8_t data_type,
+    uint8_t compression_type,
     const void* input,
     uint64_t count,
     void* output,
@@ -186,8 +186,8 @@ uint64_t om_decode_decompress(
 }
 
 void om_decode_filter(
-    const OmDataType_t data_type,
-    const OmCompression_t compression_type,
+    uint8_t data_type,
+    uint8_t compression_type,
     void* data,
     uint64_t length_in_chunk,
     uint64_t length_last,
@@ -245,8 +245,8 @@ void om_decode_filter(
 }
 
 void om_decode_copy(
-    const OmDataType_t data_type,
-    const OmCompression_t compression_type,
+    uint8_t data_type,
+    uint8_t compression_type,
     uint64_t count,
     float scale_factor,
     float add_offset,

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -110,7 +110,7 @@ OmError_t om_decoder_init(
     return error;
 }
 
-uint64_t om_decode_decompress(
+ALWAYS_INLINE uint64_t om_decode_decompress(
     OmDataType_t data_type,
     OmCompression_t compression_type,
     const void* input,
@@ -185,7 +185,7 @@ uint64_t om_decode_decompress(
     return result;
 }
 
-void om_decode_filter(
+ALWAYS_INLINE void om_decode_filter(
     OmDataType_t data_type,
     OmCompression_t compression_type,
     void* data,
@@ -244,7 +244,7 @@ void om_decode_filter(
     }
 }
 
-void om_decode_copy(
+ALWAYS_INLINE void om_decode_copy(
     OmDataType_t data_type,
     OmCompression_t compression_type,
     uint64_t count,

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -36,7 +36,7 @@ OmError_t om_encoder_init(
     return error;
 }
 
-uint64_t om_encode_compress(
+ALWAYS_INLINE uint64_t om_encode_compress(
     OmDataType_t data_type,
     OmCompression_t compression_type,
     const void* input,
@@ -113,7 +113,7 @@ uint64_t om_encode_compress(
     return result;
 }
 
-void om_encode_filter(
+ALWAYS_INLINE void om_encode_filter(
     OmDataType_t data_type,
     OmCompression_t compression_type,
     void* data,
@@ -174,7 +174,7 @@ void om_encode_filter(
     }
 }
 
-void om_encode_copy(
+ALWAYS_INLINE void om_encode_copy(
     OmDataType_t data_type,
     OmCompression_t compression_type,
     uint64_t count,

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -15,8 +15,8 @@ OmError_t om_encoder_init(
     OmEncoder_t* encoder,
     float scale_factor,
     float add_offset,
-    uint8_t compression,
-    uint8_t data_type,
+    OmCompression_t compression,
+    OmDataType_t data_type,
     const uint64_t* dimensions,
     const uint64_t* chunks,
     uint64_t dimension_count
@@ -37,8 +37,8 @@ OmError_t om_encoder_init(
 }
 
 uint64_t om_encode_compress(
-    uint8_t data_type,
-    uint8_t compression_type,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
     const void* input,
     uint64_t count,
     void* output,
@@ -114,8 +114,8 @@ uint64_t om_encode_compress(
 }
 
 void om_encode_filter(
-    uint8_t data_type,
-    uint8_t compression_type,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
     void* data,
     uint64_t length_in_chunk,
     uint64_t length_last,
@@ -175,8 +175,8 @@ void om_encode_filter(
 }
 
 void om_encode_copy(
-    uint8_t data_type,
-    uint8_t compression_type,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
     uint64_t count,
     float scale_factor,
     float add_offset,

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -10,6 +10,7 @@
 #include "vp4.h"
 #include "fp.h"
 #include "delta2d.h"
+#include "conf.h"
 
 OmError_t om_encoder_init(
     OmEncoder_t* encoder,
@@ -28,10 +29,10 @@ OmError_t om_encoder_init(
     encoder->dimension_count = dimension_count;
     encoder->data_type = data_type;
     encoder->compression = compression;
-    encoder->bytes_per_element = OM_BYTES_PER_ELEMENT[data_type];
+    encoder->bytes_per_element = om_get_bytes_per_element(data_type);
 
-    uint8_t bytes_per_element_compressed = 0;
-    OmError_t error = om_get_bytes_per_element_compressed(data_type, compression, &bytes_per_element_compressed);
+    OmError_t error = ERROR_OK;
+    uint8_t bytes_per_element_compressed = om_get_bytes_per_element_compressed(data_type, compression, &error);
     encoder->bytes_per_element_compressed = bytes_per_element_compressed;
     return error;
 }

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -15,8 +15,8 @@ OmError_t om_encoder_init(
     OmEncoder_t* encoder,
     float scale_factor,
     float add_offset,
-    OmCompression_t compression,
-    OmDataType_t data_type,
+    uint8_t compression,
+    uint8_t data_type,
     const uint64_t* dimensions,
     const uint64_t* chunks,
     uint64_t dimension_count
@@ -38,8 +38,8 @@ OmError_t om_encoder_init(
 }
 
 uint64_t om_encode_compress(
-    const OmDataType_t data_type,
-    const OmCompression_t compression_type,
+    uint8_t data_type,
+    uint8_t compression_type,
     const void* input,
     uint64_t count,
     void* output,
@@ -115,8 +115,8 @@ uint64_t om_encode_compress(
 }
 
 void om_encode_filter(
-    OmDataType_t data_type,
-    OmCompression_t compression_type,
+    uint8_t data_type,
+    uint8_t compression_type,
     void* data,
     uint64_t length_in_chunk,
     uint64_t length_last,
@@ -176,8 +176,8 @@ void om_encode_filter(
 }
 
 void om_encode_copy(
-    OmDataType_t data_type,
-    OmCompression_t compression_type,
+    uint8_t data_type,
+    uint8_t compression_type,
     uint64_t count,
     float scale_factor,
     float add_offset,
@@ -292,7 +292,7 @@ uint64_t om_encoder_lut_buffer_size(const uint64_t* lookUpTable, uint64_t lookUp
         const uint64_t len = p4ndenc64((uint64_t*)&lookUpTable[rangeStart], rangeEnd - rangeStart, (unsigned char *)buffer);
         if (len > maxLength) maxLength = len;
     }
-    /// Compression function can write 32 integers more
+    // Compression function can write 32 integers more
     return maxLength * nLutChunks + 32 * sizeof(uint64_t);
 }
 

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -97,7 +97,6 @@ ALWAYS_INLINE uint64_t om_encode_compress(
                 case DATA_TYPE_DOUBLE_ARRAY:
                     result = p4nzenc64((uint64_t*)input, (size_t)count, (unsigned char*)output);
                     break;
-
                 case DATA_TYPE_NONE:
                 case DATA_TYPE_STRING:
                 case DATA_TYPE_STRING_ARRAY:


### PR DESCRIPTION
Removed the function callbacks from the encoder and decoder structs. Particularly, they led to RuntimeErrors when compiling the code for WASM with emscripten. I think this is because calling function pointers after casting them to a different type  may result in [undefined behavior](https://stackoverflow.com/questions/559581/casting-a-function-pointer-to-another-type/559671#559671).

Also sorry for my IDE removing all the trailing white space from the changed files, it adds a lot of noise to the diff...  :frowning_face:   Maybe removing trailing white space is something we could agree on generally, in order to keep diffs small? In VSCode it can be set [like this](https://stackoverflow.com/a/30884298), in Xcode [like this](https://stackoverflow.com/a/11830067).