### PR TITLE
fix: tests for all array types

### DIFF
--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -8,25 +8,25 @@ import Foundation
         #expect(om_header_size() == 40)
         #expect(om_trailer_size() == 24)
         #expect(om_header_write_size() == 3)
-        
+
         #expect(om_header_type([UInt8(79), 77, 3]) == OM_HEADER_READ_TRAILER)
         #expect(om_header_type([UInt8(79), 77, 1]) == OM_HEADER_LEGACY)
         #expect(om_header_type([UInt8(79), 77, 2]) == OM_HEADER_LEGACY)
         #expect(om_header_type([UInt8(77), 77, 3]) == OM_HEADER_INVALID)
-        
+
         var size: UInt64 = 0
         var offset: UInt64 = 0
         #expect(om_trailer_read([UInt8(79), 77, 3, 0, 0, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0], &offset, &size))
         #expect(size == 124)
         #expect(offset == 88)
-        
+
         #expect(!om_trailer_read([UInt8(77), 77, 3, 0, 0, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0], &offset, &size))
-        
+
         var header = [UInt8](repeating: 255, count: om_header_write_size())
         om_header_write(&header)
         #expect(om_header_type(header) == OM_HEADER_READ_TRAILER)
         #expect(header == [79, 77, 3])
-        
+
         var trailer = [UInt8](repeating: 255, count: om_trailer_size())
         om_trailer_write(&trailer, 634764573452346, 45673452346)
         #expect(om_trailer_read(trailer, &offset, &size))
@@ -34,18 +34,18 @@ import Foundation
         #expect(offset == 634764573452346)
         #expect(trailer == [79, 77, 3, 0, 0, 0, 0, 0, 58, 168, 234, 164, 80, 65, 2, 0, 58, 147, 89, 162, 10, 0, 0, 0])
     }
-    
+
     @Test func variable() {
         var name = "name"
         name.withUTF8({ name in
             let sizeScalar = om_variable_write_scalar_size(UInt16(name.count), 0, DATA_TYPE_INT8)
             #expect(sizeScalar == 13)
-            
+
             var data = [UInt8](repeating: 255, count: sizeScalar)
             var value = UInt8(177)
             om_variable_write_scalar(&data, UInt16(name.count), 0, nil, nil, name.baseAddress, DATA_TYPE_INT8, &value)
             #expect(data == [1, 4, 4, 0, 0, 0, 0, 0, 177, 110, 97, 109, 101])
-            
+
             let omvariable = om_variable_init(data)
             #expect(om_variable_get_type(omvariable) == DATA_TYPE_INT8)
             #expect(om_variable_get_children_count(omvariable) == 0)
@@ -54,7 +54,7 @@ import Foundation
             #expect(valueOut == 177)
         })
     }
-    
+
     @Test func inMemory() throws {
         let data: [Float] = [0.0, 5.0, 2.0, 3.0, 2.0, 5.0, 6.0, 2.0, 8.0, 3.0, 10.0, 14.0, 12.0, 15.0, 14.0, 15.0, 66.0, 17.0, 12.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0]
         let compressed = try OmFileWriter(dim0: 1, dim1: data.count, chunk0: 1, chunk1: 10).writeInMemory(compressionType: .pfor_delta2d_int16, scalefactor: 1, all: data)
@@ -62,7 +62,7 @@ import Foundation
         let uncompressed = try OmFileReader(fn: DataAsClass(data: compressed)).readAll()
         #expect(data == uncompressed)
     }
-    
+
     /// Make sure the last chunk has the correct number of chunks
     @Test func writeMoreDataThenExpected() throws {
         let file = "writeMoreDataThenExpected.om"
@@ -82,46 +82,46 @@ import Foundation
         }) }
         try FileManager.default.removeItem(atPath: "\(file)~")
     }
-    
+
     @Test func writeLarge() async throws {
         let file = "writeLarge.om"
         try FileManager.default.removeItemIfExists(at: file)
         let fn = try FileHandle.createNewFile(file: file)
-        
+
         let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
         let writer = try fileWriter.prepareArray(type: Float.self, dimensions: [100,100,10], chunkDimensions: [2,2,2], compression: .pfor_delta2d_int16, scale_factor: 1, add_offset: 0)
-        
+
         let data = (0..<100000).map({Float($0 % 10000)})
         try writer.writeData(array: data)
         let variableMeta = try writer.finalise()
         let variable = try fileWriter.write(array: variableMeta, name: "data", children: [])
         try fileWriter.writeTrailer(rootVariable: variable)
-        
+
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
         let read = try OmFileReader2(fn: readFn).asArray(of: Float.self)!
-        
+
         let a1 = try read.read(range: [50..<51, 20..<21, 1..<2])
         #expect(a1 == [201.0])
-                
+
         let a = try await read.readConcurrent(range: [0..<100, 0..<100, 0..<10])
         #expect(a == data)
-        
+
         #expect(readFn.count == 154176)
         //let hex = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none)
         //XCTAssertEqual(hex, "awfawf")
-        
+
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func writeChunks() throws {
         let file = "writeChunks.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let fn = try FileHandle.createNewFile(file: file)
         let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
-        
+
         let writer = try fileWriter.prepareArray(type: Float.self, dimensions: [5,5], chunkDimensions: [2,2], compression: .pfor_delta2d_int16, scale_factor: 1, add_offset: 0)
-        
+
         // Directly feed individual chunks
         try writer.writeData(array: [0.0, 1.0, 5.0, 6.0], arrayDimensions: [2,2])
         try writer.writeData(array: [2.0, 3.0, 7.0, 8.0], arrayDimensions: [2,2])
@@ -135,38 +135,38 @@ import Foundation
         let variableMeta = try writer.finalise()
         let variable = try fileWriter.write(array: variableMeta, name: "data", children: [])
         try fileWriter.writeTrailer(rootVariable: variable)
-        
+
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
         let read = try OmFileReader2(fn: readFn).asArray(of: Float.self)!
-        
+
         let a = try read.read(range: [0..<5, 0..<5])
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         #expect(readFn.count == 144)
         //let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{UInt8($0)}
         // difference on x86 and ARM cause by the underlying compression
         //XCTAssertTrue(bytes == [79, 77, 3, 0, 4, 130, 0, 2, 3, 34, 0, 4, 194, 2, 10, 4, 178, 0, 12, 4, 242, 0, 14, 197, 17, 20, 194, 2, 22, 194, 2, 24, 3, 3, 228, 200, 109, 1, 0, 0, 20, 0, 4, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97, 0, 0, 0, 0, 79, 77, 3, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 0] || bytes == [79, 77, 3, 0, 4, 130, 64, 2, 3, 34, 16, 4, 194, 2, 10, 4, 178, 64, 12, 4, 242, 64, 14, 197, 17, 20, 194, 2, 22, 194, 2, 24, 3, 3, 228, 200, 109, 1, 0, 0, 20, 0, 4, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97, 0, 0, 0, 0, 79, 77, 3, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 0])
-        
+
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func offsetWrite() throws {
         let file = "offsetWrite.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let fn = try FileHandle.createNewFile(file: file)
         let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
-        
+
         let writer = try fileWriter.prepareArray(type: Float.self, dimensions: [5,5], chunkDimensions: [2,2], compression: .pfor_delta2d_int16, scale_factor: 1, add_offset: 0)
-        
+
         /// Deliberately add NaN on all positions that should not be written to the file. Only the inner 5x5 array is written
         let data = [.nan, .nan, .nan, .nan, .nan, .nan, .nan, .nan, Float(0.0), 1.0, 2.0, 3.0, 4.0, .nan, .nan, 5.0, 6.0, 7.0, 8.0, 9.0, .nan, .nan, 10.0, 11.0, 12.0, 13.0, 14.0, .nan, .nan, 15.0, 16.0, 17.0, 18.0, 19.0, .nan, .nan, 20.0, 21.0, 22.0, 23.0, 24.0, .nan, .nan, .nan, .nan, .nan, .nan, .nan, .nan]
         try writer.writeData(array: data, arrayDimensions: [7,7], arrayOffset: [1, 1], arrayCount: [5, 5])
-        
+
         let variableMeta = try writer.finalise()
         let variable = try fileWriter.write(array: variableMeta, name: "data", children: [])
         try fileWriter.writeTrailer(rootVariable: variable)
-        
+
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
         let readFile = try OmFileReader2(fn: readFn)
         let read = readFile.asArray(of: Float.self)!
@@ -179,37 +179,37 @@ import Foundation
         #expect(read.getDimensions()[1] == 5)
         #expect(read.getChunkDimensions()[0] == 2)
         #expect(read.getChunkDimensions()[1] == 2)
-        
+
         let a = try read.read(range: [0..<5, 0..<5])
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func write3D() throws {
         let file = "write3D.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let dims = [UInt64(3),3,3]
         let data = [Float(0.0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0]
-        
+
         let fn = try FileHandle.createNewFile(file: file)
         let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
-        
+
         let writer = try fileWriter.prepareArray(type: Float.self, dimensions: dims, chunkDimensions: [2,2,2], compression: .pfor_delta2d_int16, scale_factor: 1, add_offset: 0)
         try writer.writeData(array: data)
         let variableMeta = try writer.finalise()
-        
+
         let int32Attribute = try fileWriter.write(value: Int32(12323154), name: "int32", children: [])
         let doubleAttribute = try fileWriter.write(value: Double(12323154), name: "double", children: [])
         let variable = try fileWriter.write(array: variableMeta, name: "data", children: [int32Attribute, doubleAttribute])
-        
+
         try fileWriter.writeTrailer(rootVariable: variable)
-        
+
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
         let readFile = try OmFileReader2(fn: readFn)
         let read = readFile.asArray(of: Float.self)!
-        
+
         #expect(readFile.numberOfChildren == 2)
         let child = readFile.getChild(0)!
         #expect(child.readScalar() == Int32(12323154))
@@ -218,10 +218,10 @@ import Foundation
         #expect(child2.readScalar() == Double(12323154))
         #expect(child2.getName() == "double")
         #expect(readFile.getChild(2) == nil)
-        
+
         let a = try read.read(range: [0..<3, 0..<3, 0..<3])
         #expect(a == data)
-        
+
         // single index
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
@@ -230,7 +230,7 @@ import Foundation
                 }
             }
         }
-        
+
         // Ensure written bytes are correct
         #expect(readFn.count == 240)
         let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{UInt8($0)}
@@ -249,40 +249,40 @@ import Foundation
         #expect(bytes[65..<65+22] == [4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 64, 42, 129, 103, 65, 100, 111, 117, 98, 108, 101, 0]) // scalar double // scalar double
         #expect(bytes[88..<88+124] == [20, 0, 4, 0, 2, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97]) // array meta // array meta
         #expect(bytes[216..<240] == [79, 77, 3, 0, 0, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0]) // trailer // trailer
-        
+
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func writev3() throws {
         let file = "writev3.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let dims = [UInt64(5),5]
         let fn = try FileHandle.createNewFile(file: file)
         let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
-        
+
         let writer = try fileWriter.prepareArray(type: Float.self, dimensions: dims, chunkDimensions: [2,2], compression: .pfor_delta2d_int16, scale_factor: 1, add_offset: 0)
-        
+
         let data = [Float(0.0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0]
         try writer.writeData(array: data)
         let variableMeta = try writer.finalise()
         let variable = try fileWriter.write(array: variableMeta, name: "data", children: [])
         try fileWriter.writeTrailer(rootVariable: variable)
-        
+
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
         let read = try OmFileReader2(fn: readFn).asArray(of: Float.self)!
-        
+
 
         let a = try read.read(range: [0..<5, 0..<5])
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         // single index
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
                 #expect(try read.read(range: [x..<x+1, y..<y+1]) == [Float(x*5 + y)])
             }
         }
-        
+
         // Read into an existing array with an offset
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
@@ -293,21 +293,21 @@ import Foundation
                 #expect(r.testSimilar([.nan, .nan, .nan, .nan, Float(x*5 + y), .nan, .nan, .nan, .nan]))
             }
         }
-        
+
         // 2x in fast dim
         for x in 0..<dims[0] {
             for y in 0..<dims[1]-1 {
                 #expect(try read.read(range: [x..<x+1, y..<y+2]) == [Float(x*5 + y), Float(x*5 + y + 1)])
             }
         }
-        
+
         // 2x in slow dim
         for x in 0..<dims[0]-1 {
             for y in 0..<dims[1] {
                 #expect(try read.read(range: [x..<x+2, y..<y+1]) == [Float(x*5 + y), Float((x+1)*5 + y)])
             }
         }
-        
+
         // 2x2
         for x in 0..<dims[0]-1 {
             for y in 0..<dims[1]-1 {
@@ -320,21 +320,21 @@ import Foundation
                 #expect(try read.read(range: [x..<x+3, y..<y+3]) == [Float(x*5 + y), Float(x*5 + y + 1), Float(x*5 + y + 2), Float((x+1)*5 + y), Float((x+1)*5 + y + 1),  Float((x+1)*5 + y + 2), Float((x+2)*5 + y), Float((x+2)*5 + y + 1),  Float((x+2)*5 + y + 2)])
             }
         }
-        
+
         // 1x5
         for x in 0..<dims[1] {
             #expect(try read.read(range: [x..<x+1, 0..<5]) == [Float(x*5), Float(x*5+1), Float(x*5+2), Float(x*5+3), Float(x*5+4)])
         }
-        
+
         // 5x1
         for x in 0..<dims[0] {
             #expect(try read.read(range: [0..<5, x..<x+1]) == [Float(x), Float(x+5), Float(x+10), Float(x+15), Float(x+20)])
         }
-        
+
         #expect(readFn.count == 144)
         let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{UInt8($0)}
         #expect(bytes == [79, 77, 3, 0, 4, 130, 0, 2, 3, 34, 0, 4, 194, 2, 10, 4, 178, 0, 12, 4, 242, 0, 14, 197, 17, 20, 194, 2, 22, 194, 2, 24, 3, 3, 228, 200, 109, 1, 0, 0, 20, 0, 4, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97, 0, 0, 0, 0, 79, 77, 3, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 0])
-        
+
         /*// test interpolation
         XCTAssertEqualArray(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.5, dim0Y: 0, dim0YFraction: 0.5, dim0Nx: 2, dim1: 0..<5), [7.5, 8.5, 9.5, 10.5, 11.5], accuracy: 0.001)
         XCTAssertEqualArray(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.1, dim0Y: 0, dim0YFraction: 0.2, dim0Nx: 2, dim1: 0..<5), [2.5, 3.4999998, 4.5, 5.5, 6.5], accuracy: 0.001)
@@ -343,37 +343,37 @@ import Foundation
         XCTAssertEqualArray(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.8, dim0Y: 0, dim0YFraction: 0.9, dim0Nx: 2, dim1: 0..<5), [12.999999, 14.0, 15.0, 16.0, 17.0], accuracy: 0.001)*/
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func writev3MaxIOLimit() throws {
         let file = "writev3MaxIOLimit.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let dims = [UInt64(5),5]
         let fn = try FileHandle.createNewFile(file: file)
         let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
-        
+
         let writer = try fileWriter.prepareArray(type: Float.self, dimensions: dims, chunkDimensions: [2,2], compression: .pfor_delta2d_int16, scale_factor: 1, add_offset: 0)
-        
+
         let data = [Float(0.0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0]
         try writer.writeData(array: data)
         let variableMeta = try writer.finalise()
         let variable = try fileWriter.write(array: variableMeta, name: "data", children: [])
         try fileWriter.writeTrailer(rootVariable: variable)
-        
+
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
         let read = try OmFileReader2(fn: readFn).asArray(of: Float.self, io_size_max: 0, io_size_merge: 0)!
-        
+
 
         let a = try read.read(range: [0..<5, 0..<5])
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         // single index
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
                 #expect(try read.read(range: [x..<x+1, y..<y+1]) == [Float(x*5 + y)])
             }
         }
-        
+
         // Read into an existing array with an offset
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
@@ -384,21 +384,21 @@ import Foundation
                 #expect(r.testSimilar([.nan, .nan, .nan, .nan, Float(x*5 + y), .nan, .nan, .nan, .nan]))
             }
         }
-        
+
         // 2x in fast dim
         for x in 0..<dims[0] {
             for y in 0..<dims[1]-1 {
                 #expect(try read.read(range: [x..<x+1, y..<y+2]) == [Float(x*5 + y), Float(x*5 + y + 1)])
             }
         }
-        
+
         // 2x in slow dim
         for x in 0..<dims[0]-1 {
             for y in 0..<dims[1] {
                 #expect(try read.read(range: [x..<x+2, y..<y+1]) == [Float(x*5 + y), Float((x+1)*5 + y)])
             }
         }
-        
+
         // 2x2
         for x in 0..<dims[0]-1 {
             for y in 0..<dims[1]-1 {
@@ -411,17 +411,17 @@ import Foundation
                 #expect(try read.read(range: [x..<x+3, y..<y+3]) == [Float(x*5 + y), Float(x*5 + y + 1), Float(x*5 + y + 2), Float((x+1)*5 + y), Float((x+1)*5 + y + 1),  Float((x+1)*5 + y + 2), Float((x+2)*5 + y), Float((x+2)*5 + y + 1),  Float((x+2)*5 + y + 2)])
             }
         }
-        
+
         // 1x5
         for x in 0..<dims[1] {
             #expect(try read.read(range: [x..<x+1, 0..<5]) == [Float(x*5), Float(x*5+1), Float(x*5+2), Float(x*5+3), Float(x*5+4)])
         }
-        
+
         // 5x1
         for x in 0..<dims[0] {
             #expect(try read.read(range: [0..<5, x..<x+1]) == [Float(x), Float(x+5), Float(x+10), Float(x+15), Float(x+20)])
         }
-        
+
         /*// test interpolation
         XCTAssertEqualArray(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.5, dim0Y: 0, dim0YFraction: 0.5, dim0Nx: 2, dim1: 0..<5), [7.5, 8.5, 9.5, 10.5, 11.5], accuracy: 0.001)
         XCTAssertEqualArray(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.1, dim0Y: 0, dim0YFraction: 0.2, dim0Nx: 2, dim1: 0..<5), [2.5, 3.4999998, 4.5, 5.5, 6.5], accuracy: 0.001)
@@ -430,13 +430,13 @@ import Foundation
         XCTAssertEqualArray(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.8, dim0Y: 0, dim0YFraction: 0.9, dim0Nx: 2, dim1: 0..<5), [12.999999, 14.0, 15.0, 16.0, 17.0], accuracy: 0.001)*/
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func oldWriterNewReader() throws {
         let file = "oldWriterNewReader.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let fn = try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .pfor_delta2d_int16, scalefactor: 1, overwrite: false, supplyChunk: { dim0pos in
-            
+
             if dim0pos == 0 {
                 return ArraySlice((0..<10).map({ Float($0) }))
             }
@@ -448,22 +448,22 @@ import Foundation
             }
             fatalError("Not expected")
         })
-        
+
         let io_size_max: UInt64 = 1000000
         let io_size_merge: UInt64 = 100000
-        
+
         let read = try OmFileReader2(fn: try MmapFile(fn: fn)).asArray(of: Float.self, io_size_max: io_size_max, io_size_merge: io_size_merge)!
         let dims = read.getDimensions()
         let a = try read.read(range: [0..<5, 0..<5])
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         // single index
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
                 #expect(try read.read(range: [x..<x+1, y..<y+1]) == [Float(x*5 + y)])
             }
         }
-        
+
         // Read into an existing array with an offset
         for x in 0..<dims[0] {
             for y in 0..<dims[1] {
@@ -474,21 +474,21 @@ import Foundation
                 #expect(r.testSimilar([.nan, .nan, .nan, .nan, Float(x*5 + y), .nan, .nan, .nan, .nan]))
             }
         }
-        
+
         // 2x in fast dim
         for x in 0..<dims[0] {
             for y in 0..<dims[1]-1 {
                 #expect(try read.read(range: [x..<x+1, y..<y+2]) == [Float(x*5 + y), Float(x*5 + y + 1)])
             }
         }
-        
+
         // 2x in slow dim
         for x in 0..<dims[0]-1 {
             for y in 0..<dims[1] {
                 #expect(try read.read(range: [x..<x+2, y..<y+1]) == [Float(x*5 + y), Float((x+1)*5 + y)])
             }
         }
-        
+
         // 2x2
         for x in 0..<dims[0]-1 {
             for y in 0..<dims[1]-1 {
@@ -501,26 +501,26 @@ import Foundation
                 #expect(try read.read(range: [x..<x+3, y..<y+3]) == [Float(x*5 + y), Float(x*5 + y + 1), Float(x*5 + y + 2), Float((x+1)*5 + y), Float((x+1)*5 + y + 1),  Float((x+1)*5 + y + 2), Float((x+2)*5 + y), Float((x+2)*5 + y + 1),  Float((x+2)*5 + y + 2)])
             }
         }
-        
+
         // 1x5
         for x in 0..<dims[1] {
             #expect(try read.read(range: [x..<x+1, 0..<5]) == [Float(x*5), Float(x*5+1), Float(x*5+2), Float(x*5+3), Float(x*5+4)])
         }
-        
+
         // 5x1
         for x in 0..<dims[0] {
             #expect(try read.read(range: [0..<5, x..<x+1]) == [Float(x), Float(x+5), Float(x+10), Float(x+15), Float(x+20)])
         }
         try FileManager.default.removeItem(atPath: file)
     }
-    
-    
+
+
     @Test func write() throws {
         let file = "write.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .pfor_delta2d_int16, scalefactor: 1, overwrite: false, supplyChunk: { dim0pos in
-            
+
             if dim0pos == 0 {
                 return ArraySlice((0..<10).map({ Float($0) }))
             }
@@ -532,32 +532,32 @@ import Foundation
             }
             fatalError("Not expected")
         })
-        
+
         let read = try OmFileReader(file: file)
         let a = try read.read(dim0Slow: 0..<5, dim1: 0..<5)
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         // single index
         for x in 0..<read.dim0 {
             for y in 0..<read.dim1 {
                 #expect(try read.read(dim0Slow: x..<x+1, dim1: y..<y+1) == [Float(x*5 + y)])
             }
         }
-        
+
         // 2x in fast dim
         for x in 0..<read.dim0 {
             for y in 0..<read.dim1-1 {
                 #expect(try read.read(dim0Slow: x..<x+1, dim1: y..<y+2) == [Float(x*5 + y), Float(x*5 + y + 1)])
             }
         }
-        
+
         // 2x in slow dim
         for x in 0..<read.dim0-1 {
             for y in 0..<read.dim1 {
                 #expect(try read.read(dim0Slow: x..<x+2, dim1: y..<y+1) == [Float(x*5 + y), Float((x+1)*5 + y)])
             }
         }
-        
+
         // 2x2
         for x in 0..<read.dim0-1 {
             for y in 0..<read.dim1-1 {
@@ -570,17 +570,17 @@ import Foundation
                 #expect(try read.read(dim0Slow: x..<x+3, dim1: y..<y+3) == [Float(x*5 + y), Float(x*5 + y + 1), Float(x*5 + y + 2), Float((x+1)*5 + y), Float((x+1)*5 + y + 1),  Float((x+1)*5 + y + 2), Float((x+2)*5 + y), Float((x+2)*5 + y + 1),  Float((x+2)*5 + y + 2)])
             }
         }
-        
+
         // 1x5
         for x in 0..<read.dim1 {
             #expect(try read.read(dim0Slow: x..<x+1, dim1: 0..<5) == [Float(x*5), Float(x*5+1), Float(x*5+2), Float(x*5+3), Float(x*5+4)])
         }
-        
+
         // 5x1
         for x in 0..<read.dim0 {
             #expect(try read.read(dim0Slow: 0..<5, dim1: x..<x+1) == [Float(x), Float(x+5), Float(x+10), Float(x+15), Float(x+20)])
         }
-        
+
         // test interpolation
         #expect(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.5, dim0Y: 0, dim0YFraction: 0.5, dim0Nx: 2, dim1: 0..<5) == [7.5, 8.5, 9.5, 10.5, 11.5])
         #expect(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.1, dim0Y: 0, dim0YFraction: 0.2, dim0Nx: 2, dim1: 0..<5) == [2.5, 3.4999998, 4.5, 5.5, 6.5])
@@ -589,27 +589,27 @@ import Foundation
         #expect(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.8, dim0Y: 0, dim0YFraction: 0.9, dim0Nx: 2, dim1: 0..<5) == [12.999999, 14.0, 15.0, 16.0, 17.0])
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func naN() throws {
         let file = "naN.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let data = (0..<(5*5)).map({ val in Float.nan })
         try OmFileWriter(dim0: 5, dim1: 5, chunk0: 5, chunk1: 5).write(file: file, compressionType: .pfor_delta2d_int16, scalefactor: 1, all: data)
-        
+
         let read = try OmFileReader(file: file)
         let data2 = try read.read(dim0Slow: nil, dim1: nil)
         print(data2)
         #expect(try read.read(dim0Slow: 1..<2, dim1: 1..<2)[0].isNaN)
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func writeFpx() throws {
         let file = "writeFpx.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .fpx_xor2d, scalefactor: 1, overwrite: false, supplyChunk: { dim0pos in
-            
+
             if dim0pos == 0 {
                 return ArraySlice((0..<10).map({ Float($0) }))
             }
@@ -621,32 +621,32 @@ import Foundation
             }
             fatalError("Not expected")
         })
-        
+
         let read = try OmFileReader(file: file)
         let a = try read.read(dim0Slow: 0..<5, dim1: 0..<5)
         #expect(a == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0])
-        
+
         // single index
         for x in 0..<read.dim0 {
             for y in 0..<read.dim1 {
                 #expect(try read.read(dim0Slow: x..<x+1, dim1: y..<y+1) == [Float(x*5 + y)])
             }
         }
-        
+
         // 2x in fast dim
         for x in 0..<read.dim0 {
             for y in 0..<read.dim1-1 {
                 #expect(try read.read(dim0Slow: x..<x+1, dim1: y..<y+2) == [Float(x*5 + y), Float(x*5 + y + 1)])
             }
         }
-        
+
         // 2x in slow dim
         for x in 0..<read.dim0-1 {
             for y in 0..<read.dim1 {
                 #expect(try read.read(dim0Slow: x..<x+2, dim1: y..<y+1) == [Float(x*5 + y), Float((x+1)*5 + y)])
             }
         }
-        
+
         // 2x2
         for x in 0..<read.dim0-1 {
             for y in 0..<read.dim1-1 {
@@ -659,33 +659,189 @@ import Foundation
                 #expect(try read.read(dim0Slow: x..<x+3, dim1: y..<y+3) == [Float(x*5 + y), Float(x*5 + y + 1), Float(x*5 + y + 2), Float((x+1)*5 + y), Float((x+1)*5 + y + 1),  Float((x+1)*5 + y + 2), Float((x+2)*5 + y), Float((x+2)*5 + y + 1),  Float((x+2)*5 + y + 2)])
             }
         }
-        
+
         // 1x5
         for x in 0..<read.dim1 {
             #expect(try read.read(dim0Slow: x..<x+1, dim1: 0..<5) == [Float(x*5), Float(x*5+1), Float(x*5+2), Float(x*5+3), Float(x*5+4)])
         }
-        
+
         // 5x1
         for x in 0..<read.dim0 {
             #expect(try read.read(dim0Slow: 0..<5, dim1: x..<x+1) == [Float(x), Float(x+5), Float(x+10), Float(x+15), Float(x+20)])
         }
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
     @Test func naNfpx() throws {
         let file = "naNfpx.om"
         try FileManager.default.removeItemIfExists(at: file)
-        
+
         let data = (0..<(5*5)).map({ val in Float.nan })
         try OmFileWriter(dim0: 5, dim1: 5, chunk0: 5, chunk1: 5).write(file: file, compressionType: .fpx_xor2d, scalefactor: 1, all: data)
-        
+
         let read = try OmFileReader(file: file)
         let data2 = try read.read(dim0Slow: nil, dim1: nil)
         print(data2)
         #expect(try read.read(dim0Slow: 1..<2, dim1: 1..<2)[0].isNaN)
         try FileManager.default.removeItem(atPath: file)
     }
-    
+
+    @Test func writeReadOmFileTypes() throws {
+        let types: [OmFileArrayDataTypeProtocol.Type] = [
+            Float.self, Double.self,
+            Int8.self, Int16.self, Int32.self, Int.self,
+            UInt8.self, UInt16.self, UInt32.self, UInt.self
+        ]
+        for type in types {
+            let file = "test_file_\(type).om"
+            try FileManager.default.removeItemIfExists(at: file)
+
+            do {
+                defer { try? FileManager.default.removeItem(atPath: file) }
+                let fn = try FileHandle.createNewFile(file: file)
+                let fileWriter = OmFileWriter2(fn: fn, initialCapacity: 8)
+
+                let intValues = (0..<25).map({ _ in Int.random(in: Int.min..<Int.max) })
+                let uintValues = (0..<25).map({ _ in UInt.random(in: 0..<UInt.max) })
+
+
+                let variableMeta: OmFileWriterArrayFinalised = try {
+                    switch type {
+                    case is Float.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: Float.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in Float.random(in: 0..<1) }))
+                        return try writer.finalise()
+                    case is Double.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: Double.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in Double.random(in: 0..<1) }))
+                        return try writer.finalise()
+                    case is Int8.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: Int8.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in Int8.random(in: Int8.min..<Int8.max) }))
+                        return try writer.finalise()
+                    case is Int16.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: Int16.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in Int16.random(in: Int16.min..<Int16.max) }))
+                        return try writer.finalise()
+                    case is Int32.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: Int32.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in Int32.random(in: Int32.min..<Int32.max) }))
+                        return try writer.finalise()
+                    case is Int.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: Int.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: intValues)
+                        return try writer.finalise()
+                    case is UInt8.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: UInt8.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in UInt8.random(in: 0..<UInt8.max) }))
+                        return try writer.finalise()
+                    case is UInt16.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: UInt16.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in UInt16.random(in: 0..<UInt16.max) }))
+                        return try writer.finalise()
+                    case is UInt32.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: UInt32.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: (0..<25).map({ _ in UInt32.random(in: 0..<UInt32.max) }))
+                        return try writer.finalise()
+                    case is UInt.Type:
+                        let writer = try fileWriter.prepareArray(
+                            type: UInt.self, dimensions: [5, 5], chunkDimensions: [2, 2],
+                            compression: .pfor_delta2d, scale_factor: 10000, add_offset: 0)
+                        try writer.writeData(array: uintValues)
+                        return try writer.finalise()
+
+                    default:
+                        fatalError("Unsupported type \(type)")
+                    }
+                }()
+
+                let variable = try fileWriter.write(array: variableMeta, name: "data", children: [])
+                try fileWriter.writeTrailer(rootVariable: variable)
+
+                let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
+                let readFile = try OmFileReader2(fn: readFn)
+
+                switch type {
+                case is Float.Type:
+                    let array = readFile.asArray(of: Float.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is Double.Type:
+                    let array = readFile.asArray(of: Double.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is Int8.Type:
+                    let array = readFile.asArray(of: Int8.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is Int16.Type:
+                    let array = readFile.asArray(of: Int16.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is Int32.Type:
+                    let array = readFile.asArray(of: Int32.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is Int.Type:
+                    let array = readFile.asArray(of: Int.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    let values = try array.read(range: [0..<5, 0..<5])
+                    #expect(values == intValues)
+                case is UInt8.Type:
+                    let array = readFile.asArray(of: UInt8.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is UInt16.Type:
+                    let array = readFile.asArray(of: UInt16.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is UInt32.Type:
+                    let array = readFile.asArray(of: UInt32.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    _ = try array.read(range: [0..<5, 0..<5])
+                case is UInt.Type:
+                    let array = readFile.asArray(of: UInt.self)!
+                    #expect(array.getDimensions()[0] == 5)
+                    #expect(array.getDimensions()[1] == 5)
+                    let values = try array.read(range: [0..<5, 0..<5])
+                    #expect(values == uintValues)
+
+                default:
+                    fatalError("Unsupported type")
+                }
+            } catch {
+                Issue.record("Error: \(error)")
+            }
+        }
+    }
+
     @Test func copyLog10Roundtrip() {
         let ints: [Int16] = [100, 200, 300, 400, 500]
         var floats = [Float](repeating: 0, count: ints.count)

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -307,7 +307,7 @@ ALWAYS_INLINE void om_decode_copy(
                     break;
                 case DATA_TYPE_INT64_ARRAY:
                 case DATA_TYPE_UINT64_ARRAY:
-                    om_common_copy32(count, scale_factor, add_offset, input, output);
+                    om_common_copy64(count, scale_factor, add_offset, input, output);
                     break;
                 case DATA_TYPE_DOUBLE_ARRAY:
                     om_common_copy_int64_to_double(count, scale_factor, add_offset, input, output);
@@ -504,7 +504,7 @@ bool om_decoder_next_data_read(const OmDecoder_t *decoder, OmDecoder_dataRead_t*
 
     uint64_t chunkIndex = data_read->nextChunk.lowerBound;
     data_read->chunkIndex.lowerBound = chunkIndex;
-    
+
     const uint64_t number_of_chunks = decoder->number_of_chunks;
 
     // Version 1 case

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -32,7 +32,7 @@ OmError_t om_encoder_init(
             return ERROR_INVALID_CHUNK_DIMENSIONS;
         }
     }
-    
+
     encoder->scale_factor = scale_factor;
     encoder->add_offset = add_offset;
     encoder->dimensions = dimensions;
@@ -231,7 +231,7 @@ ALWAYS_INLINE void om_encode_copy(
                     break;
                 case DATA_TYPE_INT64_ARRAY:
                 case DATA_TYPE_UINT64_ARRAY:
-                    om_common_copy32(count, scale_factor, add_offset, input, output);
+                    om_common_copy64(count, scale_factor, add_offset, input, output);
                     break;
                 case DATA_TYPE_DOUBLE_ARRAY:
                     om_common_copy_double_to_int64(count, scale_factor, add_offset, input, output);


### PR DESCRIPTION
Adds a roundtrip test for all (currently) supported array types and fixes the copy-call for int64/uin64