### PR TITLE
fix: add support for DATA_TYPE_NONE to om_variable_write_scalar

### DIFF
--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -55,6 +55,27 @@ import Foundation
         })
     }
 
+    @Test func variableNone() {
+        var name = "name"
+        name.withUTF8({ name in
+            let sizeScalar = om_variable_write_scalar_size(UInt16(name.count), 0, DATA_TYPE_NONE)
+            #expect(sizeScalar == 12) // 8 (header) + 4 (name length) + 0 (no value)
+
+            var data = [UInt8](repeating: 255, count: sizeScalar)
+            // No value parameter needed for DATA_TYPE_NONE
+            om_variable_write_scalar(&data, UInt16(name.count), 0, nil, nil, name.baseAddress, DATA_TYPE_NONE, nil)
+            #expect(data == [0, 4, 4, 0, 0, 0, 0, 0, 110, 97, 109, 101])
+
+            let omvariable = om_variable_init(data)
+            #expect(om_variable_get_type(omvariable) == DATA_TYPE_NONE)
+            #expect(om_variable_get_children_count(omvariable) == 0)
+
+            // For DATA_TYPE_NONE, attempting to get scalar value should return ERROR_INVALID_DATA_TYPE
+            var dummyValue = UInt8(0)
+            #expect(om_variable_get_scalar(omvariable, &dummyValue) == ERROR_INVALID_DATA_TYPE)
+        })
+    }
+
     /*@Test func inMemory() throws {
         let data: [Float] = [0.0, 5.0, 2.0, 3.0, 2.0, 5.0, 6.0, 2.0, 8.0, 3.0, 10.0, 14.0, 12.0, 15.0, 14.0, 15.0, 66.0, 17.0, 12.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0]
         let compressed = try OmFileWriter(dim0: 1, dim1: data.count, chunk0: 1, chunk1: 10).writeInMemory(compressionType: .pfor_delta2d_int16, scalefactor: 1, all: data)

--- a/c/include/om_variable.h
+++ b/c/include/om_variable.h
@@ -130,7 +130,29 @@ OmError_t om_variable_get_scalar(const OmVariable_t* variable, void* value);
 /// Get the length of a scalar variable if written to a file
 size_t om_variable_write_scalar_size(uint16_t name_size, uint32_t children_count, OmDataType_t data_type);
 
-/// Write a scalar variable with name and children variables
+/// Write a scalar variable with name and children variables to a destination buffer
+///
+/// This function supports the following data types:
+/// - DATA_TYPE_NONE: No value storage (passing a NULL pointer to value is allowed)
+/// - DATA_TYPE_INT8/UINT8: 8-bit integer value
+/// - DATA_TYPE_INT16/UINT16: 16-bit integer value
+/// - DATA_TYPE_INT32/UINT32: 32-bit integer value
+/// - DATA_TYPE_INT64/UINT64: 64-bit integer value
+/// - DATA_TYPE_FLOAT: 32-bit floating point value
+/// - DATA_TYPE_DOUBLE: 64-bit floating point value
+///
+/// @param dst Destination buffer to write the variable to
+/// @param name_size Length of the variable name in bytes
+/// @param children_count Number of child variables
+/// @param children_offsets Array of offsets to child variables (can be NULL if children_count is 0)
+/// @param children_sizes Array of sizes of child variables (can be NULL if children_count is 0)
+/// @param name Pointer to the variable name string
+/// @param data_type Type of the data to be stored (see OmDataType_t)
+/// @param value Pointer to the value to be stored. For DATA_TYPE_NONE, this should be NULL.
+///             For other types, this should point to a value of the corresponding C type.
+///
+/// @note The destination buffer must be large enough to hold the variable.
+///       Use om_variable_write_scalar_size() to calculate the required size.
 void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, OmDataType_t data_type, const void* value);
 
 /// Get the size of meta attributes of a numeric array if written to a file. Does not contain any data. Only offsets for the actual data.

--- a/c/src/om_variable.c
+++ b/c/src/om_variable.c
@@ -259,6 +259,10 @@ void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_c
     char* destValue = (char*)(dst + sizeof(OmVariableV3_t) + 16 * children_count);
     uint8_t valueSize = 0;
     switch (data_type) {
+        case DATA_TYPE_NONE:
+            // No value to write for DATA_TYPE_NONE
+            valueSize = 0;
+            break;
         case DATA_TYPE_INT8:
         case DATA_TYPE_UINT8:
             *(int8_t *)destValue = *(int8_t*)value;


### PR DESCRIPTION
This would allow to be able to simply create groups of variables. 

However, maybe it is preferable to make a separate function `om_variable_write_group` to have a better logical separation from the scalar methods, e.g. it might be confusing that a None-type variable cannot be read with `om_variable_read_scalar`. 
In this case, I would suggest to also remove `DATA_TYPE_NONE` from the `om_variable_write_scalar_size` function.