### PR TITLE
feat: better rust bindgen enum types

### DIFF
--- a/rust/om-file-format-sys/build.rs
+++ b/rust/om-file-format-sys/build.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
+use bindgen::EnumVariation;
+
 struct BuildConfig {
     // target: String,
     arch: String,
@@ -81,6 +83,12 @@ fn generate_bindings(submodule: &str, sysroot: &Option<String>) {
         )
         .clang_arg(format!("-I{}/include", submodule))
         .header(format!("{}/include/om_file_format.h", submodule))
+        // This tells bindgen to generate Rust enums.
+        // Rust enums have the downside of potentially causing UB
+        // if the C code for some reason returns a value that is not defined in the enum.
+        // Since we are in control of the C code, we can ensure that it only returns valid values!
+        // https://mdaverde.com/posts/rust-bindgen-enum/
+        .default_enum_style(EnumVariation::Rust { non_exhaustive: false })
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
This changes how `bindgen` spits out enumerations.

The old (default) behavior `constified_enum` was producing something like:

```rust
pub type OmDataType_t = ::std::os::raw::c_uint;
pub const OmCompression_t_COMPRESSION_PFOR_DELTA2D_INT16: OmCompression_t = 0;
pub const OmCompression_t_COMPRESSION_FPX_XOR2D: OmCompression_t = 1;
pub const OmCompression_t_COMPRESSION_PFOR_DELTA2D: OmCompression_t = 2;
pub const OmCompression_t_COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC: OmCompression_t = 3;
pub const OmCompression_t_COMPRESSION_NONE: OmCompression_t = 4;
```

while the rust enum behavior will give us:

```rust
#[repr(u32)]
#[doc = " Compression types"]
#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
pub enum OmCompression_t {
    COMPRESSION_PFOR_DELTA2D_INT16 = 0,
    COMPRESSION_FPX_XOR2D = 1,
    COMPRESSION_PFOR_DELTA2D = 2,
    COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC = 3,
    COMPRESSION_NONE = 4,
}
```

With the new approach, it is particularly important that the C-code never spits out any value incompatible with rust enumerations as this might cause undefined behavior. I think it is still safe to assume this, because we are in full control of the C-code and I don't see any place where we treat the enumeration types badly, thus producing values which are incompatible with the rust enumeration.