### PR TITLE
chore: update ubuntu runners in swift test workflow

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -62,7 +62,7 @@ jobs:
             container: "swift:6.0"
           - swift: "6.1"
             container: "swift:6.1"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     name: Linux
     steps:


### PR DESCRIPTION
Ubuntu-20.04 runners are deprecated:https://github.com/actions/runner-images/tree/fd1af56b4f367781036decb0f9a569d4bd5382ac?tab=readme-ov-file#available-images