### PR TITLE
Libaec

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let swiftFlags: [PackageDescription.SwiftSetting] = [
 
 // Note: Fast math flags reduce performance for compression
 let cFlagsPFor2D = [PackageDescription.CSetting.unsafeFlags(["-O3"] + mArch)]
-let cFlagsPFor = [PackageDescription.CSetting.unsafeFlags(["-O3", "-Wall", "-Werror", "-Wimplicit-fallthrough", "-Wextra"] + mArch)]
+let cFlagsPFor = [PackageDescription.CSetting.unsafeFlags(["-O3"] + mArch)]
 
 
 let package = Package(

--- a/Swift/OmFileFormat/OmFileFormat.swift
+++ b/Swift/OmFileFormat/OmFileFormat.swift
@@ -65,6 +65,8 @@ public enum CompressionType: UInt8, Codable {
 
     ///  Similar to `pfor_delta2d_int16` but applies `log10(1+x)` before
     case pfor_delta2d_int16_logarithmic = 3
+    
+    case aec = 5
 
     func toC() -> OmCompression_t {
         switch self {
@@ -76,6 +78,8 @@ public enum CompressionType: UInt8, Codable {
             return COMPRESSION_PFOR_DELTA2D
         case .pfor_delta2d_int16_logarithmic:
             return COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC
+        case .aec:
+            return COMPRESSION_AEC
         }
     }
 }

--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -205,7 +205,7 @@ import Foundation
         let fileWriter = OmFileWriter(fn: fn, initialCapacity: 8)
         let dims = Array(referenceData.getDimensions())
         print(dims)
-        let writer = try fileWriter.prepareArray(type: Float.self, dimensions: dims, chunkDimensions: dims, compression: .aec, scale_factor: 20, add_offset: referenceData.scaleFactor)
+        let writer = try fileWriter.prepareArray(type: Float.self, dimensions: dims, chunkDimensions: dims, compression: .aec, scale_factor: referenceData.scaleFactor, add_offset: referenceData.addOffset)
 
         try writer.writeData(array: data)
         let variableMeta = try writer.finalise()
@@ -216,12 +216,19 @@ import Foundation
         let read = try OmFileReader(fn: readFn).asArray(of: Float.self)!
 
         let a1 = try read.read(range: [50..<51, 20..<21])
-        #expect(a1 == [201.0])
+        #expect(a1 == [-16.55])
 
         //let a = try await read.read()
         //#expect(a == data)
 
-        #expect(readFn.count == 580648)
+        #expect(readFn.count == 580288)
+        // om file 684k
+        // rsi 128, block 64 = 580528 w 507 blocks
+        // no delta2d = 580304 -> even slightly better
+        // 32 bit => 589392
+        // 32 bit unsigned => 712424 (AEC_DATA_SIGNED means that data is signed, then libaec does zigzag encoding)
+        // 32 bit signed by add 100K, remove AEC_DATA_SIGNED => 589376
+        // No difference in file size if +100 on values versus AES_DATA_SIGNED
         //let hex = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none)
         //XCTAssertEqual(hex, "awfawf")
     }

--- a/c/include/config.h
+++ b/c/include/config.h
@@ -1,0 +1,7 @@
+//
+//  config.h
+//  om-file-format
+//
+//  Created by Patrick Zippenfenig on 20.04.2025.
+//
+

--- a/c/include/decode.h
+++ b/c/include/decode.h
@@ -1,0 +1,129 @@
+/**
+ * @file decode.h
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Decoder
+ * Based on the CCSDS recommended standard 121.0-B-3
+ *
+ */
+
+#ifndef DECODE_H
+#define DECODE_H 1
+
+#include "config.h"
+#include <stdint.h>
+#include <stddef.h>
+#include "vector.h"
+
+#define M_CONTINUE 1
+#define M_EXIT 0
+#define M_ERROR (-1)
+
+#define MIN(a, b) (((a) < (b))? (a): (b))
+
+#define SE_TABLE_SIZE 90
+
+struct aec_stream;
+
+struct internal_state {
+    int (*mode)(struct aec_stream *);
+
+    /* option ID */
+    int id;
+
+    /* bit length of code option identification key */
+    int id_len;
+
+    /* table maps IDs to states */
+    int (**id_table)(struct aec_stream *);
+
+    void (*flush_output)(struct aec_stream *);
+
+    /* previous output for post-processing */
+    int32_t last_out;
+
+    /* minimum integer for post-processing */
+    uint32_t xmin;
+
+    /* maximum integer for post-processing */
+    uint32_t xmax;
+
+     /* length of uncompressed input block should be the longest
+        legal block */
+    uint32_t in_blklen;
+
+    /* length of output block in bytes */
+    uint32_t out_blklen;
+
+    uint32_t sample_counter;
+
+    /* accumulator for currently used bit sequence */
+    uint64_t acc;
+
+    /* bit pointer to the next unused bit in accumulator */
+    int bitp;
+
+    /* last fundamental sequence in accumulator */
+    uint32_t fs;
+
+    /* 1 if current block has reference sample */
+    int ref;
+
+    /* block_size minus reference sample if present */
+    uint32_t encoded_block_size;
+
+    /* 1 if postprocessor has to be used */
+    int pp;
+
+    /* storage size of samples in bytes */
+    uint32_t bytes_per_sample;
+
+    /* output buffer holding one reference sample interval */
+    uint32_t *rsi_buffer;
+
+    /* current position of output in rsi_buffer */
+    uint32_t *rsip;
+
+    /* rsi in bytes */
+    size_t rsi_size;
+
+    /* first not yet flushed byte in rsi_buffer */
+    uint32_t *flush_start;
+
+    /* table for decoding second extension option */
+    int se_table[2 * (SE_TABLE_SIZE + 1)];
+
+    /* RSI table */
+    struct vector_t *offsets;
+};
+
+#endif /* DECODE_H */

--- a/c/include/encode.h
+++ b/c/include/encode.h
@@ -1,0 +1,152 @@
+/**
+ * @file encode.h
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Encoder
+ * Based on the CCSDS recommended standard 121.0-B-3
+ *
+ */
+
+#ifndef ENCODE_H
+#define ENCODE_H 1
+
+#include "vector.h"
+#include "config.h"
+#include <stdint.h>
+
+#define M_CONTINUE 1
+#define M_EXIT 0
+#define MIN(a, b) (((a) < (b))? (a): (b))
+
+/* Maximum CDS length in bytes: 5 bits ID, 64 * 32 bits samples, 7
+ * bits carry from previous CDS */
+#define CDSLEN ((5 + 64 * 32 + 7 + 7) / 8)
+
+/* Marker for Remainder Of Segment condition in zero block encoding */
+#define ROS -1
+
+struct aec_stream;
+
+struct internal_state {
+    int (*mode)(struct aec_stream *);
+    uint32_t (*get_sample)(struct aec_stream *);
+    void (*get_rsi)(struct aec_stream *);
+    void (*preprocess)(struct aec_stream *);
+
+    /* bit length of code option identification key */
+    int id_len;
+
+    /* minimum integer for preprocessing */
+    uint32_t xmin;
+
+    /* maximum integer for preprocessing */
+    uint32_t xmax;
+
+    uint32_t i;
+
+    /* RSI blocks of preprocessed input */
+    uint32_t *data_pp;
+
+    /* RSI blocks of input */
+    uint32_t *data_raw;
+
+    /* remaining blocks in buffer */
+    int blocks_avail;
+
+    /* blocks encoded so far in RSI */
+    int blocks_dispensed;
+
+    /* current (preprocessed) input block */
+    uint32_t *block;
+
+    /* reference sample interval in byte */
+    uint32_t rsi_len;
+
+    /* current Coded Data Set output */
+    uint8_t *cds;
+
+    /* buffer for one CDS (only used if strm->next_out cannot hold
+     * full CDS) */
+    uint8_t cds_buf[CDSLEN];
+
+    /* cds points to strm->next_out (1) or cds_buf (0) */
+    int direct_out;
+
+    /* Free bits (LSB) in output buffer or accumulator */
+    int bits;
+
+    /* length of reference sample in current block i.e. 0 or 1
+     * depending on whether the block has a reference sample or not */
+    int ref;
+
+    /* reference sample stored here for performance reasons */
+    uint32_t ref_sample;
+
+    /* current zero block has a reference sample */
+    int zero_ref;
+
+    /* reference sample of zero block */
+    uint32_t zero_ref_sample;
+
+    /* storage size of samples in bytes */
+    uint32_t bytes_per_sample;
+
+    /* number of contiguous zero blocks */
+    int zero_blocks;
+
+    /* 1 if this is the first non-zero block after one or more zero
+     * blocks */
+    int block_nonzero;
+
+    /* splitting position */
+    int k;
+
+    /* maximum number for k depending on id_len */
+    int kmax;
+
+    /* flush option copied from argument */
+    int flush;
+
+    /* 1 if flushing was successful */
+    int flushed;
+
+    /* length of uncompressed CDS */
+    uint32_t uncomp_len;
+
+    /* RSI offsets container */
+    struct vector_t *offsets;
+
+    /* indicator if an RSI should be captured */
+    int ready_to_capture_rsi;
+};
+
+#endif /* ENCODE_H */

--- a/c/include/encode_accessors.h
+++ b/c/include/encode_accessors.h
@@ -1,0 +1,61 @@
+/**
+ * @file encode_accessors.h
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Read various data types from input stream
+ *
+ */
+
+#ifndef ENCODE_ACCESSORS_H
+#define ENCODE_ACCESSORS_H 1
+
+#include "config.h"
+#include "libaec.h"
+#include <stdint.h>
+
+uint32_t aec_get_8(struct aec_stream *strm);
+uint32_t aec_get_lsb_16(struct aec_stream *strm);
+uint32_t aec_get_msb_16(struct aec_stream *strm);
+uint32_t aec_get_lsb_32(struct aec_stream *strm);
+uint32_t aec_get_msb_24(struct aec_stream *strm);
+uint32_t aec_get_lsb_24(struct aec_stream *strm);
+uint32_t aec_get_msb_32(struct aec_stream *strm);
+
+void aec_get_rsi_8(struct aec_stream *strm);
+void aec_get_rsi_lsb_16(struct aec_stream *strm);
+void aec_get_rsi_msb_16(struct aec_stream *strm);
+void aec_get_rsi_lsb_24(struct aec_stream *strm);
+void aec_get_rsi_msb_24(struct aec_stream *strm);
+void aec_get_rsi_lsb_32(struct aec_stream *strm);
+void aec_get_rsi_msb_32(struct aec_stream *strm);
+
+#endif /* ENCODE_ACCESSORS_H */

--- a/c/include/libaec.h
+++ b/c/include/libaec.h
@@ -1,0 +1,183 @@
+/**
+ * @file libaec.h
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Coding library
+ *
+ */
+
+#ifndef LIBAEC_H
+#define LIBAEC_H 1
+
+#define AEC_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+#define AEC_VERSION_MINOR @PROJECT_VERSION_MINOR@
+#define AEC_VERSION_PATCH @PROJECT_VERSION_PATCH@
+#define AEC_VERSION_STR "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+#if defined LIBAEC_BUILD && HAVE_VISIBILITY
+#  define LIBAEC_DLL_EXPORTED __attribute__((__visibility__("default")))
+#elif (defined _WIN32 && !defined __CYGWIN__) && defined LIBAEC_SHARED
+#  if defined LIBAEC_BUILD
+#    define LIBAEC_DLL_EXPORTED __declspec(dllexport)
+#  else
+#    define LIBAEC_DLL_EXPORTED __declspec(dllimport)
+#  endif
+#else
+#  define LIBAEC_DLL_EXPORTED
+#endif
+
+struct internal_state;
+
+struct aec_stream {
+    const unsigned char *next_in;
+
+    /* number of bytes available at next_in */
+    size_t avail_in;
+
+    /* total number of input bytes read so far */
+    size_t total_in;
+
+    unsigned char *next_out;
+
+    /* remaining free space at next_out */
+    size_t avail_out;
+
+    /* total number of bytes output so far */
+    size_t total_out;
+
+    /* resolution in bits per sample (n = 1, ..., 32) */
+    unsigned int bits_per_sample;
+
+    /* block size in samples */
+    unsigned int block_size;
+
+    /* Reference sample interval, the number of blocks
+     * between consecutive reference samples (up to 4096). */
+    unsigned int rsi;
+
+    unsigned int flags;
+
+    struct internal_state *state;
+};
+
+/*********************************/
+/* Sample data description flags */
+/*********************************/
+
+/* Samples are signed. Telling libaec this results in a slightly
+ * better compression ratio. Default is unsigned. */
+#define AEC_DATA_SIGNED 1
+
+/* 24 bit samples are coded in 3 bytes */
+#define AEC_DATA_3BYTE 2
+
+/* Samples are stored with their most significant bit first. This has
+ * nothing to do with the endianness of the host. Default is LSB. */
+#define AEC_DATA_MSB 4
+
+/* Set if preprocessor should be used */
+#define AEC_DATA_PREPROCESS 8
+
+/* Use restricted set of code options */
+#define AEC_RESTRICTED 16
+
+/* Pad RSI to byte boundary. Only used for decoding some CCSDS sample
+ * data. Do not use this to produce new data as it violates the
+ * standard. */
+#define AEC_PAD_RSI 32
+
+/* Do not enforce standard regarding legal block sizes. */
+#define AEC_NOT_ENFORCE 64
+
+/*************************************/
+/* Return codes of library functions */
+/*************************************/
+#define AEC_OK 0
+#define AEC_CONF_ERROR (-1)
+#define AEC_STREAM_ERROR (-2)
+#define AEC_DATA_ERROR (-3)
+#define AEC_MEM_ERROR (-4)
+#define AEC_RSI_OFFSETS_ERROR (-5)
+
+/************************/
+/* Options for flushing */
+/************************/
+
+/* Do not enforce output flushing. More input may be provided with
+ * later calls. So far only relevant for encoding. */
+#define AEC_NO_FLUSH 0
+
+/* Flush output and end encoding. The last call to aec_encode() must
+ * set AEC_FLUSH to drain all output.
+ *
+ * It is not possible to continue encoding of the same stream after it
+ * has been flushed. For one, the last block may be padded zeros after
+ * preprocessing. Secondly, the last encoded byte may be padded with
+ * fill bits. */
+#define AEC_FLUSH 1
+
+/*********************************************/
+/* Streaming encoding and decoding functions */
+/*********************************************/
+LIBAEC_DLL_EXPORTED int aec_encode_init(struct aec_stream *strm);
+LIBAEC_DLL_EXPORTED int aec_encode_enable_offsets(struct aec_stream *strm);
+LIBAEC_DLL_EXPORTED int aec_encode_count_offsets(struct aec_stream *strm, size_t *rsi_offsets_count);
+LIBAEC_DLL_EXPORTED int aec_encode_get_offsets(struct aec_stream *strm, size_t *rsi_offsets, size_t rsi_offsets_count);
+LIBAEC_DLL_EXPORTED int aec_buffer_seek(struct aec_stream *strm, size_t offset);
+LIBAEC_DLL_EXPORTED int aec_encode(struct aec_stream *strm, int flush);
+LIBAEC_DLL_EXPORTED int aec_encode_end(struct aec_stream *strm);
+
+LIBAEC_DLL_EXPORTED int aec_decode_init(struct aec_stream *strm);
+LIBAEC_DLL_EXPORTED int aec_decode_enable_offsets(struct aec_stream *strm);
+LIBAEC_DLL_EXPORTED int aec_decode_count_offsets(struct aec_stream *strm, size_t *rsi_offsets_count);
+LIBAEC_DLL_EXPORTED int aec_decode_get_offsets(struct aec_stream *strm, size_t *rsi_offsets, size_t rsi_offsets_count);
+LIBAEC_DLL_EXPORTED int aec_decode(struct aec_stream *strm, int flush);
+LIBAEC_DLL_EXPORTED int aec_decode_range(struct aec_stream *strm, const size_t *rsi_offsets, size_t rsi_offsets_count, size_t pos, size_t size);
+LIBAEC_DLL_EXPORTED int aec_decode_end(struct aec_stream *strm);
+
+/***************************************************************/
+/* Utility functions for encoding or decoding a memory buffer. */
+/***************************************************************/
+LIBAEC_DLL_EXPORTED int aec_buffer_encode(struct aec_stream *strm);
+LIBAEC_DLL_EXPORTED int aec_buffer_decode(struct aec_stream *strm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBAEC_H */

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -66,7 +66,8 @@ typedef enum {
     COMPRESSION_FPX_XOR2D = 1, // Lossless float/double compression using 2D xor coding.
     COMPRESSION_PFOR_DELTA2D = 2, // PFor integer compression. Floating point values are scaled to 32 bit signed integers. Doubles are scaled to 64 bit signed integers.
     COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC = 3, // Similar to `COMPRESSION_PFOR_DELTA2D_INT16` but applies `log10(1+x)` before.
-    COMPRESSION_NONE = 4
+    COMPRESSION_NONE = 4,
+    COMPRESSION_AEC = 5
 } OmCompression_t;
 
 /// Get the number of bytes per element.

--- a/c/include/szlib.h
+++ b/c/include/szlib.h
@@ -1,0 +1,82 @@
+/**
+ * @file szlib.h
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Coding library
+ *
+ */
+
+#ifndef SZLIB_H
+#define SZLIB_H 1
+
+#include <libaec.h>
+
+#define SZ_ALLOW_K13_OPTION_MASK 1
+#define SZ_CHIP_OPTION_MASK 2
+#define SZ_EC_OPTION_MASK 4
+#define SZ_LSB_OPTION_MASK 8
+#define SZ_MSB_OPTION_MASK 16
+#define SZ_NN_OPTION_MASK 32
+#define SZ_RAW_OPTION_MASK 128
+
+#define SZ_OK AEC_OK
+#define SZ_OUTBUFF_FULL 2
+
+#define SZ_NO_ENCODER_ERROR -1
+#define SZ_PARAM_ERROR AEC_CONF_ERROR
+#define SZ_MEM_ERROR AEC_MEM_ERROR
+
+#define SZ_MAX_PIXELS_PER_BLOCK 32
+#define SZ_MAX_BLOCKS_PER_SCANLINE 128
+#define SZ_MAX_PIXELS_PER_SCANLINE                              \
+    (SZ_MAX_BLOCKS_PER_SCANLINE) * (SZ_MAX_PIXELS_PER_BLOCK)
+
+typedef struct SZ_com_t_s
+{
+    int options_mask;
+    int bits_per_pixel;
+    int pixels_per_block;
+    int pixels_per_scanline;
+} SZ_com_t;
+
+LIBAEC_DLL_EXPORTED int SZ_BufftoBuffCompress(
+    void *dest, size_t *destLen,
+    const void *source, size_t sourceLen,
+    SZ_com_t *param);
+LIBAEC_DLL_EXPORTED int SZ_BufftoBuffDecompress(
+    void *dest, size_t *destLen,
+    const void *source, size_t sourceLen,
+    SZ_com_t *param);
+
+LIBAEC_DLL_EXPORTED int SZ_encoder_enabled(void);
+
+#endif /* SZLIB_H */

--- a/c/include/vector.h
+++ b/c/include/vector.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "config.h"
+#include <stdlib.h>
+
+struct vector_t {
+    size_t size;
+    size_t capacity;
+    size_t *values;
+};
+
+struct vector_t*  vector_create();
+void vector_destroy(struct vector_t* vec);
+size_t vector_size(struct vector_t* vec);
+void vector_push_back(struct vector_t *vec, size_t offset);
+size_t vector_at(struct vector_t *vector, size_t idx);
+int vector_equal(struct vector_t *vec1, struct vector_t *vec2);
+size_t* vector_data(struct vector_t *vec);

--- a/c/src/decode.c
+++ b/c/src/decode.c
@@ -1,0 +1,953 @@
+/**
+ * @file decode.c
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Decoder
+ * Based on the CCSDS recommended standard 121.0-B-3
+ *
+ */
+
+#include "config.h"
+#include "decode.h"
+#include "libaec.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef HAVE_BSR64
+#include <intrin.h>
+#endif
+
+#define ROS 5
+#define RSI_USED_SIZE(state) ((size_t)(state->rsip - state->rsi_buffer))
+#define BUFFERSPACE(strm) (strm->avail_in >= strm->state->in_blklen      \
+                           && strm->avail_out >= strm->state->out_blklen)
+
+#define FLUSH(KIND)                                                      \
+    static void flush_##KIND(struct aec_stream *strm)                    \
+    {                                                                    \
+        uint32_t *flush_end, *bp, half_d;                                \
+        uint32_t xmax, d, data, m;                                       \
+        struct internal_state *state = strm->state;                      \
+                                                                         \
+        flush_end = state->rsip;                                         \
+        if (state->pp) {                                                 \
+            if (state->flush_start == state->rsi_buffer                  \
+                && state->rsip > state->rsi_buffer) {                    \
+                state->last_out = *state->rsi_buffer;                    \
+                                                                         \
+                if (strm->flags & AEC_DATA_SIGNED) {                     \
+                    m = UINT32_C(1) << (strm->bits_per_sample - 1);      \
+                    /* Reference samples have to be sign extended */     \
+                    state->last_out = (state->last_out ^ m) - m;         \
+                }                                                        \
+                put_##KIND(strm, (uint32_t)state->last_out);             \
+                state->flush_start++;                                    \
+            }                                                            \
+                                                                         \
+            data = state->last_out;                                      \
+            xmax = state->xmax;                                          \
+                                                                         \
+            if (state->xmin == 0) {                                      \
+                uint32_t med;                                            \
+                med = state->xmax / 2 + 1;                               \
+                                                                         \
+                for (bp = state->flush_start; bp < flush_end; bp++) {    \
+                    uint32_t mask;                                       \
+                    d = *bp;                                             \
+                    half_d = (d >> 1) + (d & 1);                         \
+                    /*in this case: data >= med == data & med */         \
+                    mask = (data & med)?xmax:0;                          \
+                                                                         \
+                    /*in this case: xmax - data == xmax ^ data */        \
+                    if (half_d <= (mask ^ data)) {                       \
+                        data += (d >> 1)^(~((d & 1) - 1));               \
+                    } else {                                             \
+                        data = mask ^ d;                                 \
+                    }                                                    \
+                    put_##KIND(strm, data);                              \
+                }                                                        \
+                state->last_out = data;                                  \
+            } else {                                                     \
+                for (bp = state->flush_start; bp < flush_end; bp++) {    \
+                    d = *bp;                                             \
+                    half_d = (d >> 1) + (d & 1);                         \
+                                                                         \
+                    if ((int32_t)data < 0) {                             \
+                        if (half_d <= xmax + data + 1) {                 \
+                            data += (d >> 1)^(~((d & 1) - 1));           \
+                        } else {                                         \
+                            data = d - xmax - 1;                         \
+                        }                                                \
+                    } else {                                             \
+                        if (half_d <= xmax - data) {                     \
+                            data += (d >> 1)^(~((d & 1) - 1));           \
+                        } else {                                         \
+                            data = xmax - d;                             \
+                        }                                                \
+                    }                                                    \
+                    put_##KIND(strm, data);                              \
+                }                                                        \
+                state->last_out = data;                                  \
+            }                                                            \
+        } else {                                                         \
+            for (bp = state->flush_start; bp < flush_end; bp++)          \
+                put_##KIND(strm, *bp);                                   \
+        }                                                                \
+        state->flush_start = state->rsip;                                \
+    }
+
+
+static inline void put_msb_32(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)(data >> 24);
+    *strm->next_out++ = (unsigned char)(data >> 16);
+    *strm->next_out++ = (unsigned char)(data >> 8);
+    *strm->next_out++ = (unsigned char)data;
+}
+
+static inline void put_msb_24(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)(data >> 16);
+    *strm->next_out++ = (unsigned char)(data >> 8);
+    *strm->next_out++ = (unsigned char)data;
+}
+
+static inline void put_msb_16(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)(data >> 8);
+    *strm->next_out++ = (unsigned char)data;
+}
+
+static inline void put_lsb_32(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)data;
+    *strm->next_out++ = (unsigned char)(data >> 8);
+    *strm->next_out++ = (unsigned char)(data >> 16);
+    *strm->next_out++ = (unsigned char)(data >> 24);
+}
+
+static inline void put_lsb_24(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)data;
+    *strm->next_out++ = (unsigned char)(data >> 8);
+    *strm->next_out++ = (unsigned char)(data >> 16);
+}
+
+static inline void put_lsb_16(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)data;
+    *strm->next_out++ = (unsigned char)(data >> 8);
+}
+
+static inline void put_8(struct aec_stream *strm, uint32_t data)
+{
+    *strm->next_out++ = (unsigned char)data;
+}
+
+FLUSH(msb_32)
+FLUSH(msb_24)
+FLUSH(msb_16)
+FLUSH(lsb_32)
+FLUSH(lsb_24)
+FLUSH(lsb_16)
+FLUSH(8)
+
+static inline void put_sample(struct aec_stream *strm, uint32_t s)
+{
+    struct internal_state *state = strm->state;
+
+    *state->rsip++ = s;
+    strm->avail_out -= state->bytes_per_sample;
+}
+
+static inline uint32_t direct_get(struct aec_stream *strm, int n)
+{
+    /**
+       Get n bit from input stream
+
+       No checking whatsoever. Read bits are dumped.
+     */
+
+    struct internal_state *state = strm->state;
+    if (state->bitp < n)
+    {
+        int b = (63 - state->bitp) >> 3;
+        if (b == 6) {
+            state->acc = (state->acc << 48)
+                | ((uint64_t)strm->next_in[0] << 40)
+                | ((uint64_t)strm->next_in[1] << 32)
+                | ((uint64_t)strm->next_in[2] << 24)
+                | ((uint64_t)strm->next_in[3] << 16)
+                | ((uint64_t)strm->next_in[4] << 8)
+                | (uint64_t)strm->next_in[5];
+        } else if (b == 7) {
+            state->acc = (state->acc << 56)
+                | ((uint64_t)strm->next_in[0] << 48)
+                | ((uint64_t)strm->next_in[1] << 40)
+                | ((uint64_t)strm->next_in[2] << 32)
+                | ((uint64_t)strm->next_in[3] << 24)
+                | ((uint64_t)strm->next_in[4] << 16)
+                | ((uint64_t)strm->next_in[5] << 8)
+                | (uint64_t)strm->next_in[6];
+        } else if (b == 5) {
+            state->acc = (state->acc << 40)
+                | ((uint64_t)strm->next_in[0] << 32)
+                | ((uint64_t)strm->next_in[1] << 24)
+                | ((uint64_t)strm->next_in[2] << 16)
+                | ((uint64_t)strm->next_in[3] << 8)
+                | (uint64_t)strm->next_in[4];
+        } else if (b == 4) {
+            state->acc = (state->acc << 32)
+                | ((uint64_t)strm->next_in[0] << 24)
+                | ((uint64_t)strm->next_in[1] << 16)
+                | ((uint64_t)strm->next_in[2] << 8)
+                | (uint64_t)strm->next_in[3];
+        } else if (b == 3) {
+            state->acc = (state->acc << 24)
+                | ((uint64_t)strm->next_in[0] << 16)
+                | ((uint64_t)strm->next_in[1] << 8)
+                | (uint64_t)strm->next_in[2];
+        } else if (b == 2) {
+            state->acc = (state->acc << 16)
+                | ((uint64_t)strm->next_in[0] << 8)
+                | (uint64_t)strm->next_in[1];
+        } else if (b == 1) {
+            state->acc = (state->acc << 8)
+                | (uint64_t)strm->next_in[0];
+        }
+        strm->next_in += b;
+        strm->avail_in -= b;
+        state->bitp += b << 3;
+    }
+
+    state->bitp -= n;
+    return (state->acc >> state->bitp) & (UINT64_MAX >> (64 - n));
+}
+
+static inline uint32_t direct_get_fs(struct aec_stream *strm)
+{
+    /**
+       Interpret a Fundamental Sequence from the input buffer.
+
+       Essentially counts the number of 0 bits until a 1 is
+       encountered.
+     */
+
+    uint32_t fs = 0;
+    struct internal_state *state = strm->state;
+
+    if (state->bitp)
+        state->acc &= UINT64_MAX >> (64 - state->bitp);
+    else
+        state->acc = 0;
+
+    while (state->acc == 0) {
+        if (strm->avail_in < 7)
+            return 0;
+
+        state->acc = (state->acc << 56)
+            | ((uint64_t)strm->next_in[0] << 48)
+            | ((uint64_t)strm->next_in[1] << 40)
+            | ((uint64_t)strm->next_in[2] << 32)
+            | ((uint64_t)strm->next_in[3] << 24)
+            | ((uint64_t)strm->next_in[4] << 16)
+            | ((uint64_t)strm->next_in[5] << 8)
+            | (uint64_t)strm->next_in[6];
+        strm->next_in += 7;
+        strm->avail_in -= 7;
+        fs += state->bitp;
+        state->bitp = 56;
+    }
+
+    {
+#ifndef __has_builtin
+#define __has_builtin(x) 0  /* Compatibility with non-clang compilers. */
+#endif
+#if HAVE_DECL___BUILTIN_CLZLL || __has_builtin(__builtin_clzll)
+        int i = 63 - __builtin_clzll(state->acc);
+#elif defined HAVE_BSR64
+        unsigned long i;
+        _BitScanReverse64(&i, state->acc);
+#else
+        int i = state->bitp - 1;
+        while ((state->acc & (UINT64_C(1) << i)) == 0)
+            i--;
+#endif
+        fs += state->bitp - i - 1;
+        state->bitp = i;
+    }
+    return fs;
+}
+
+static inline uint32_t bits_ask(struct aec_stream *strm, int n)
+{
+    while (strm->state->bitp < n) {
+        if (strm->avail_in == 0)
+            return 0;
+        strm->avail_in--;
+        strm->state->acc <<= 8;
+        strm->state->acc |= *strm->next_in++;
+        strm->state->bitp += 8;
+    }
+    return 1;
+}
+
+static inline uint32_t bits_get(struct aec_stream *strm, int n)
+{
+    return (strm->state->acc >> (strm->state->bitp - n))
+        & (UINT64_MAX >> (64 - n));
+}
+
+static inline void bits_drop(struct aec_stream *strm, int n)
+{
+    strm->state->bitp -= n;
+}
+
+static inline uint32_t fs_ask(struct aec_stream *strm)
+{
+    if (bits_ask(strm, 1) == 0)
+        return 0;
+    while ((strm->state->acc & (UINT64_C(1) << (strm->state->bitp - 1))) == 0) {
+        if (strm->state->bitp == 1) {
+            if (strm->avail_in == 0)
+                return 0;
+            strm->avail_in--;
+            strm->state->acc <<= 8;
+            strm->state->acc |= *strm->next_in++;
+            strm->state->bitp += 8;
+        }
+        strm->state->fs++;
+        strm->state->bitp--;
+    }
+    return 1;
+}
+
+static inline void fs_drop(struct aec_stream *strm)
+{
+    strm->state->fs = 0;
+    strm->state->bitp--;
+}
+
+static inline uint32_t copysample(struct aec_stream *strm)
+{
+    if (bits_ask(strm, strm->bits_per_sample) == 0
+        || strm->avail_out < strm->state->bytes_per_sample)
+        return 0;
+
+    put_sample(strm, bits_get(strm, strm->bits_per_sample));
+    bits_drop(strm, strm->bits_per_sample);
+    return 1;
+}
+
+static inline int m_id(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    if (strm->avail_in >= strm->state->in_blklen) {
+        state->id = direct_get(strm, state->id_len);
+    } else {
+        if (bits_ask(strm, state->id_len) == 0) {
+            state->mode = m_id;
+            return M_EXIT;
+        }
+        state->id = bits_get(strm, state->id_len);
+        bits_drop(strm, state->id_len);
+    }
+    state->mode = state->id_table[state->id];
+    return(state->mode(strm));
+}
+
+static int m_next_cds(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if ((state->offsets != NULL) && (state->rsi_size == RSI_USED_SIZE(state)))
+        vector_push_back(
+            state->offsets,
+            strm->total_in * 8 - (strm->avail_in * 8 + state->bitp));
+
+    if (state->rsi_size == RSI_USED_SIZE(state)) {
+        state->flush_output(strm);
+        state->flush_start = state->rsi_buffer;
+        state->rsip = state->rsi_buffer;
+        if (state->pp) {
+            state->ref = 1;
+            state->encoded_block_size = strm->block_size - 1;
+        }
+        if (strm->flags & AEC_PAD_RSI)
+            state->bitp -= state->bitp % 8;
+    } else {
+        state->ref = 0;
+        state->encoded_block_size = strm->block_size;
+    }
+    return m_id(strm);
+}
+
+static int m_split_output(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    int k = state->id - 1;
+
+    do {
+        if (bits_ask(strm, k) == 0 || strm->avail_out < state->bytes_per_sample)
+            return M_EXIT;
+        if (k)
+            *state->rsip++ += bits_get(strm, k);
+        else
+            state->rsip++;
+        strm->avail_out -= state->bytes_per_sample;
+        bits_drop(strm, k);
+    } while(++state->sample_counter < state->encoded_block_size);
+
+    state->mode = m_next_cds;
+    return M_CONTINUE;
+}
+
+static int m_split_fs(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    int k = state->id - 1;
+
+    do {
+        if (fs_ask(strm) == 0)
+            return M_EXIT;
+        state->rsip[state->sample_counter] = state->fs << k;
+        fs_drop(strm);
+    } while(++state->sample_counter < state->encoded_block_size);
+
+    state->sample_counter = 0;
+    state->mode = m_split_output;
+
+    return M_CONTINUE;
+}
+
+static int m_split(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (BUFFERSPACE(strm)) {
+        int k = state->id - 1;
+        size_t binary_part = (k * state->encoded_block_size) / 8 + 9;
+
+        if (state->ref)
+            *state->rsip++ = direct_get(strm, strm->bits_per_sample);
+
+        for (size_t i = 0; i < state->encoded_block_size; i++)
+            state->rsip[i] = direct_get_fs(strm) << k;
+
+        if (k) {
+            if (strm->avail_in < binary_part)
+                return M_ERROR;
+
+            for (size_t i = 0; i < state->encoded_block_size; i++)
+                *state->rsip++ += direct_get(strm, k);
+        } else {
+            state->rsip += state->encoded_block_size;
+        }
+
+        strm->avail_out -= state->out_blklen;
+        state->mode = m_next_cds;
+    } else {
+        if (state->ref && (copysample(strm) == 0))
+            return M_EXIT;
+        state->sample_counter = 0;
+        state->mode = m_split_fs;
+    }
+    return M_CONTINUE;
+}
+
+static int m_zero_output(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    do {
+        if (strm->avail_out < state->bytes_per_sample)
+            return M_EXIT;
+        put_sample(strm, 0);
+    } while(--state->sample_counter);
+
+    state->mode = m_next_cds;
+    return M_CONTINUE;
+}
+
+static int m_zero_block(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    uint32_t zero_blocks;
+    uint32_t zero_samples;
+    uint32_t zero_bytes;
+
+    if (fs_ask(strm) == 0)
+        return M_EXIT;
+
+    zero_blocks = state->fs + 1;
+    fs_drop(strm);
+
+    if (zero_blocks == ROS) {
+        int b = (int)RSI_USED_SIZE(state) / strm->block_size;
+        zero_blocks = MIN((int)(strm->rsi - b), 64 - (b % 64));
+    } else if (zero_blocks > ROS) {
+        zero_blocks--;
+    }
+
+    zero_samples = zero_blocks * strm->block_size - state->ref;
+    if (state->rsi_size - RSI_USED_SIZE(state) < zero_samples)
+        return M_ERROR;
+
+    zero_bytes = zero_samples * state->bytes_per_sample;
+    if (strm->avail_out >= zero_bytes) {
+        memset(state->rsip, 0, zero_samples * sizeof(uint32_t));
+        state->rsip += zero_samples;
+        strm->avail_out -= zero_bytes;
+        state->mode = m_next_cds;
+    } else {
+        state->sample_counter = zero_samples;
+        state->mode = m_zero_output;
+    }
+    return M_CONTINUE;
+}
+
+static int m_se_decode(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    while(state->sample_counter < strm->block_size) {
+        int32_t m;
+        int32_t d1;
+        if (fs_ask(strm) == 0)
+            return M_EXIT;
+        m = state->fs;
+        if (m > SE_TABLE_SIZE)
+            return M_ERROR;
+        d1 = m - state->se_table[2 * m + 1];
+
+        if ((state->sample_counter & 1) == 0) {
+            if (strm->avail_out < state->bytes_per_sample)
+                return M_EXIT;
+            put_sample(strm, state->se_table[2 * m] - d1);
+            state->sample_counter++;
+        }
+
+        if (strm->avail_out < state->bytes_per_sample)
+            return M_EXIT;
+        put_sample(strm, d1);
+        state->sample_counter++;
+        fs_drop(strm);
+    }
+
+    state->mode = m_next_cds;
+    return M_CONTINUE;
+}
+
+static int m_se(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (BUFFERSPACE(strm)) {
+        uint32_t i = state->ref;
+
+        while (i < strm->block_size) {
+            uint32_t m = direct_get_fs(strm);
+            int32_t d1;
+
+            if (m > SE_TABLE_SIZE)
+                return M_ERROR;
+
+            d1 = m - state->se_table[2 * m + 1];
+
+            if ((i & 1) == 0) {
+                put_sample(strm, state->se_table[2 * m] - d1);
+                i++;
+            }
+            put_sample(strm, d1);
+            i++;
+        }
+        state->mode = m_next_cds;
+    } else {
+        state->mode = m_se_decode;
+        state->sample_counter = state->ref;
+    }
+    return M_CONTINUE;
+}
+
+static int m_low_entropy_ref(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (state->ref && copysample(strm) == 0)
+        return M_EXIT;
+
+    if (state->id == 1)
+        state->mode = m_se;
+    else
+        state->mode = m_zero_block;
+    return M_CONTINUE;
+}
+
+static int m_low_entropy(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (bits_ask(strm, 1) == 0)
+        return M_EXIT;
+    state->id = bits_get(strm, 1);
+    bits_drop(strm, 1);
+    state->mode = m_low_entropy_ref;
+    return M_CONTINUE;
+}
+
+static int m_uncomp_copy(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    do {
+        if (copysample(strm) == 0)
+            return M_EXIT;
+    } while(--state->sample_counter);
+
+    state->mode = m_next_cds;
+    return M_CONTINUE;
+}
+
+static int m_uncomp(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (BUFFERSPACE(strm)) {
+        for (size_t i = 0; i < strm->block_size; i++)
+            *state->rsip++ = direct_get(strm, strm->bits_per_sample);
+        strm->avail_out -= state->out_blklen;
+        state->mode = m_next_cds;
+    } else {
+        state->sample_counter = strm->block_size;
+        state->mode = m_uncomp_copy;
+    }
+    return M_CONTINUE;
+}
+
+static void create_se_table(int *table)
+{
+    int k = 0;
+    for (int i = 0; i < 13; i++) {
+        int ms = k;
+        for (int j = 0; j <= i; j++) {
+            table[2 * k] = i;
+            table[2 * k + 1] = ms;
+            k++;
+        }
+    }
+}
+
+int aec_decode_init(struct aec_stream *strm)
+{
+    struct internal_state *state;
+    int modi;
+
+    if (strm->bits_per_sample > 32 || strm->bits_per_sample == 0)
+        return AEC_CONF_ERROR;
+
+    state = malloc(sizeof(struct internal_state));
+    if (state == NULL)
+        return AEC_MEM_ERROR;
+    memset(state, 0, sizeof(struct internal_state));
+
+    create_se_table(state->se_table);
+
+    strm->state = state;
+
+    if (strm->bits_per_sample > 16) {
+        state->id_len = 5;
+
+        if (strm->bits_per_sample <= 24 && strm->flags & AEC_DATA_3BYTE) {
+            state->bytes_per_sample = 3;
+            if (strm->flags & AEC_DATA_MSB)
+                state->flush_output = flush_msb_24;
+            else
+                state->flush_output = flush_lsb_24;
+        } else {
+            state->bytes_per_sample = 4;
+            if (strm->flags & AEC_DATA_MSB)
+                state->flush_output = flush_msb_32;
+            else
+                state->flush_output = flush_lsb_32;
+        }
+        state->out_blklen = strm->block_size * state->bytes_per_sample;
+    }
+    else if (strm->bits_per_sample > 8) {
+        state->bytes_per_sample = 2;
+        state->id_len = 4;
+        state->out_blklen = strm->block_size * 2;
+        if (strm->flags & AEC_DATA_MSB)
+            state->flush_output = flush_msb_16;
+        else
+            state->flush_output = flush_lsb_16;
+    } else {
+        if (strm->flags & AEC_RESTRICTED) {
+            if (strm->bits_per_sample <= 4) {
+                if (strm->bits_per_sample <= 2)
+                    state->id_len = 1;
+                else
+                    state->id_len = 2;
+            } else {
+                return AEC_CONF_ERROR;
+            }
+        } else {
+            state->id_len = 3;
+        }
+
+        state->bytes_per_sample = 1;
+        state->out_blklen = strm->block_size;
+        state->flush_output = flush_8;
+    }
+
+    if (strm->flags & AEC_DATA_SIGNED) {
+        state->xmax = (INT64_C(1) << (strm->bits_per_sample - 1)) - 1;
+        state->xmin = ~state->xmax;
+    } else {
+        state->xmin = 0;
+        state->xmax = (UINT64_C(1) << strm->bits_per_sample) - 1;
+    }
+
+    state->in_blklen = (strm->block_size * strm->bits_per_sample
+                        + state->id_len) / 8 + 16;
+
+    modi = 1UL << state->id_len;
+    state->id_table = malloc(modi * sizeof(int (*)(struct aec_stream *)));
+    if (state->id_table == NULL)
+        return AEC_MEM_ERROR;
+
+    state->id_table[0] = m_low_entropy;
+    for (int i = 1; i < modi - 1; i++) {
+        state->id_table[i] = m_split;
+    }
+    state->id_table[modi - 1] = m_uncomp;
+
+    state->rsi_size = strm->rsi * strm->block_size;
+    state->rsi_buffer = malloc(state->rsi_size * sizeof(uint32_t));
+    if (state->rsi_buffer == NULL)
+        return AEC_MEM_ERROR;
+
+    state->pp = strm->flags & AEC_DATA_PREPROCESS;
+    if (state->pp) {
+        state->ref = 1;
+        state->encoded_block_size = strm->block_size - 1;
+    } else {
+        state->ref = 0;
+        state->encoded_block_size = strm->block_size;
+    }
+    strm->total_in = 0;
+    strm->total_out = 0;
+
+    state->rsip = state->rsi_buffer;
+    state->flush_start = state->rsi_buffer;
+    state->bitp = 0;
+    state->fs = 0;
+    state->mode = m_id;
+    state->offsets = NULL;
+
+    return AEC_OK;
+}
+
+int aec_decode(struct aec_stream *strm, int flush)
+{
+    /**
+       Finite-state machine implementation of the adaptive entropy
+       decoder.
+
+       Can work with one byte input und one sample output buffers. If
+       enough buffer space is available, then faster implementations
+       of the states are called. Inspired by zlib.
+    */
+
+    struct internal_state *state = strm->state;
+    int status;
+
+    strm->total_in += strm->avail_in;
+    strm->total_out += strm->avail_out;
+
+    do {
+        status = state->mode(strm);
+    } while (status == M_CONTINUE);
+
+    if (status == M_ERROR)
+        return AEC_DATA_ERROR;
+
+    if (status == M_EXIT && strm->avail_out > 0 &&
+        strm->avail_out < state->bytes_per_sample)
+        return AEC_MEM_ERROR;
+
+    state->flush_output(strm);
+
+    strm->total_in -= strm->avail_in;
+    strm->total_out -= strm->avail_out;
+
+    return AEC_OK;
+}
+
+int aec_decode_end(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    if (state->offsets != NULL)
+        vector_destroy(state->offsets);
+
+    free(state->id_table);
+    free(state->rsi_buffer);
+    free(state);
+
+    return AEC_OK;
+}
+
+int aec_buffer_decode(struct aec_stream *strm)
+{
+    int status = aec_decode_init(strm);
+    if (status != AEC_OK)
+        return status;
+
+    status = aec_decode(strm, AEC_FLUSH);
+    aec_decode_end(strm);
+    return status;
+}
+
+int aec_buffer_seek(struct aec_stream *strm, size_t offset)
+{
+    struct internal_state *state = strm->state;
+
+    size_t byte_offset = offset / 8;
+    unsigned char bit_offset = offset % 8;
+
+    if (strm->avail_in < byte_offset)
+        return AEC_MEM_ERROR;
+
+    strm->next_in += byte_offset;
+    strm->avail_in -= byte_offset;
+
+    if (bit_offset > 0) {
+        if (strm->avail_in < 1)
+            return AEC_MEM_ERROR;
+
+        state->acc = (uint64_t)strm->next_in[0];
+        state->bitp = 8 - bit_offset;
+        strm->next_in++;
+        strm->avail_in--;
+    }
+    return AEC_OK;
+}
+
+int aec_decode_range(struct aec_stream *strm, const size_t *rsi_offsets, size_t rsi_offsets_count, size_t pos, size_t size)
+{
+    struct internal_state *state = strm->state;
+    int status;
+    size_t rsi_size;
+    size_t rsi_n;
+    unsigned char *out_tmp;
+    struct aec_stream strm_tmp = *strm;
+
+    if (state->pp) {
+        state->ref = 1;
+        state->encoded_block_size = strm->block_size - 1;
+    } else {
+        state->ref = 0;
+        state->encoded_block_size = strm->block_size;
+    }
+
+    state->rsip = state->rsi_buffer;
+    state->flush_start = state->rsi_buffer;
+    state->bitp = 0;
+    state->fs = 0;
+    state->mode = m_id;
+
+    rsi_size = strm->rsi * strm->block_size * state->bytes_per_sample;
+    rsi_n = pos / rsi_size;
+    if (rsi_n >= rsi_offsets_count)
+        return AEC_DATA_ERROR;
+
+    /* resize and align to bytes_per_sample */
+    strm_tmp.total_out = 0;
+    strm_tmp.avail_out = size + pos % rsi_size + 1;
+    strm_tmp.avail_out += state->bytes_per_sample - strm_tmp.avail_out % state->bytes_per_sample;
+    if ((out_tmp = malloc(strm_tmp.avail_out)) == NULL)
+        return AEC_MEM_ERROR;
+    strm_tmp.next_out = out_tmp;
+
+    if ((status = aec_buffer_seek(&strm_tmp, rsi_offsets[rsi_n])) != AEC_OK)
+        return status;
+
+    if ((status = aec_decode(&strm_tmp, AEC_FLUSH)) != 0)
+        return status;
+
+    memcpy(strm->next_out, out_tmp + (pos - rsi_n * rsi_size), size);
+
+    strm->next_out += size;
+    strm->avail_out -= size;
+    strm->total_out += size;
+    free(out_tmp);
+
+    return AEC_OK;
+}
+
+int aec_decode_count_offsets(struct aec_stream *strm, size_t *count)
+{
+    struct internal_state *state = strm->state;
+    if (state->offsets == NULL) {
+        *count = 0;
+        return AEC_RSI_OFFSETS_ERROR;
+    } else {
+        *count = vector_size(state->offsets);
+    }
+    return AEC_OK;
+}
+
+int aec_decode_get_offsets(struct aec_stream *strm, size_t *offsets,
+                           size_t offsets_count)
+{
+    struct internal_state *state = strm->state;
+    if (state->offsets == NULL) {
+        return AEC_RSI_OFFSETS_ERROR;
+    }
+    if (offsets_count < vector_size(state->offsets)) {
+        return AEC_MEM_ERROR;
+    }
+    memcpy(offsets, vector_data(state->offsets),
+           vector_size(state->offsets) * sizeof(size_t));
+    return AEC_OK;
+}
+
+int aec_decode_enable_offsets(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    if (state->offsets != NULL) {
+        return AEC_RSI_OFFSETS_ERROR;
+    }
+    state->offsets = vector_create();
+    vector_push_back(state->offsets, 0);
+    return AEC_OK;
+}

--- a/c/src/encode.c
+++ b/c/src/encode.c
@@ -1,0 +1,988 @@
+/**
+ * @file encode.c
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Encoder
+ * Based on the CCSDS recommended standard 121.0-B-3
+ *
+ */
+
+#include "config.h"
+#include "encode.h"
+#include "encode_accessors.h"
+#include "libaec.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int m_get_block(struct aec_stream *strm);
+
+static inline void emit(struct internal_state *state,
+                        uint32_t data, int bits)
+{
+    /**
+       Emit sequence of bits.
+     */
+
+    if (bits <= state->bits) {
+        state->bits -= bits;
+        *state->cds += (uint8_t)(data << state->bits);
+    } else {
+        bits -= state->bits;
+        *state->cds++ += (uint8_t)((uint64_t)data >> bits);
+
+        while (bits > 8) {
+            bits -= 8;
+            *state->cds++ = (uint8_t)(data >> bits);
+        }
+
+        state->bits = 8 - bits;
+        *state->cds = (uint8_t)(data << state->bits);
+    }
+}
+
+static inline void emitfs(struct internal_state *state, int fs)
+{
+    /**
+       Emits a fundamental sequence.
+
+       fs zero bits followed by one 1 bit.
+     */
+
+    for(;;) {
+        if (fs < state->bits) {
+            state->bits -= fs + 1;
+            *state->cds += 1U << state->bits;
+            break;
+        } else {
+            fs -= state->bits;
+            *++state->cds = 0;
+            state->bits = 8;
+        }
+    }
+}
+
+static inline void copy64(uint8_t *dst, uint64_t src)
+{
+    dst[0] = (uint8_t)(src >> 56);
+    dst[1] = (uint8_t)(src >> 48);
+    dst[2] = (uint8_t)(src >> 40);
+    dst[3] = (uint8_t)(src >> 32);
+    dst[4] = (uint8_t)(src >> 24);
+    dst[5] = (uint8_t)(src >> 16);
+    dst[6] = (uint8_t)(src >> 8);
+    dst[7] = (uint8_t)src;
+}
+
+static inline void emitblock_fs(struct aec_stream *strm, int k, int ref)
+{
+    struct internal_state *state = strm->state;
+
+    uint64_t acc = (uint64_t)*state->cds << 56;
+    uint32_t used = 7 - state->bits; /* used bits in 64 bit accumulator */
+
+    for (size_t i = ref; i < strm->block_size; i++) {
+        used += (state->block[i] >> k) + 1;
+        while (used > 63) {
+            copy64(state->cds, acc);
+            state->cds += 8;
+            acc = 0;
+            used -= 64;
+        }
+        acc |= UINT64_C(1) << (63 - used);
+    }
+
+    copy64(state->cds, acc);
+    state->cds += used >> 3;
+    state->bits = 7 - (used & 7);
+}
+
+static inline void emitblock(struct aec_stream *strm, int k, int ref)
+{
+    /**
+       Emit the k LSB of a whole block of input data.
+    */
+
+    struct internal_state *state = strm->state;
+    uint32_t *in = state->block + ref;
+    uint32_t *in_end = state->block + strm->block_size;
+    uint64_t mask = (UINT64_C(1) << k) - 1;
+    uint8_t *o = state->cds;
+    uint64_t a = *o;
+    int p = state->bits;
+
+    while(in < in_end) {
+        a <<= 56;
+        p = (p % 8) + 56;
+
+        while (p > k && in < in_end) {
+            p -= k;
+            a += ((uint64_t)(*in++) & mask) << p;
+        }
+
+        switch (p & ~7) {
+        case 0:
+            o[0] = (uint8_t)(a >> 56);
+            o[1] = (uint8_t)(a >> 48);
+            o[2] = (uint8_t)(a >> 40);
+            o[3] = (uint8_t)(a >> 32);
+            o[4] = (uint8_t)(a >> 24);
+            o[5] = (uint8_t)(a >> 16);
+            o[6] = (uint8_t)(a >> 8);
+            o += 7;
+            break;
+        case 8:
+            o[0] = (uint8_t)(a >> 56);
+            o[1] = (uint8_t)(a >> 48);
+            o[2] = (uint8_t)(a >> 40);
+            o[3] = (uint8_t)(a >> 32);
+            o[4] = (uint8_t)(a >> 24);
+            o[5] = (uint8_t)(a >> 16);
+            a >>= 8;
+            o += 6;
+            break;
+        case 16:
+            o[0] = (uint8_t)(a >> 56);
+            o[1] = (uint8_t)(a >> 48);
+            o[2] = (uint8_t)(a >> 40);
+            o[3] = (uint8_t)(a >> 32);
+            o[4] = (uint8_t)(a >> 24);
+            a >>= 16;
+            o += 5;
+            break;
+        case 24:
+            o[0] = (uint8_t)(a >> 56);
+            o[1] = (uint8_t)(a >> 48);
+            o[2] = (uint8_t)(a >> 40);
+            o[3] = (uint8_t)(a >> 32);
+            a >>= 24;
+            o += 4;
+            break;
+        case 32:
+            o[0] = (uint8_t)(a >> 56);
+            o[1] = (uint8_t)(a >> 48);
+            o[2] = (uint8_t)(a >> 40);
+            a >>= 32;
+            o += 3;
+            break;
+        case 40:
+            o[0] = (uint8_t)(a >> 56);
+            o[1] = (uint8_t)(a >> 48);
+            a >>= 40;
+            o += 2;
+            break;
+        case 48:
+            *o++ = (uint8_t)(a >> 56);
+            a >>= 48;
+            break;
+        default:
+            a >>= 56;
+            break;
+        }
+    }
+
+    *o = (uint8_t)a;
+    state->cds = o;
+    state->bits = p % 8;
+}
+
+static void preprocess_unsigned(struct aec_stream *strm)
+{
+    /**
+       Preprocess RSI of unsigned samples.
+
+       Combining preprocessing and converting to uint32_t in one loop
+       is slower due to the data dependence on x_i-1.
+    */
+
+    uint32_t D;
+    struct internal_state *state = strm->state;
+    const uint32_t *restrict x = state->data_raw;
+    uint32_t *restrict d = state->data_pp;
+    uint32_t xmax = state->xmax;
+    uint32_t rsi = strm->rsi * strm->block_size - 1;
+
+    state->ref = 1;
+    state->ref_sample = x[0];
+    d[0] = 0;
+    for (size_t i = 0; i < rsi; i++) {
+        if (x[i + 1] >= x[i]) {
+            D = x[i + 1] - x[i];
+            if (D <= x[i])
+                d[i + 1] = 2 * D;
+            else
+                d[i + 1] = x[i + 1];
+        } else {
+            D = x[i] - x[i + 1];
+            if (D <= xmax - x[i])
+                d[i + 1] = 2 * D - 1;
+            else
+                d[i + 1] = xmax - x[i + 1];
+        }
+    }
+    state->uncomp_len = (strm->block_size - 1) * strm->bits_per_sample;
+}
+
+static void preprocess_signed(struct aec_stream *strm)
+{
+    /**
+       Preprocess RSI of signed samples.
+    */
+
+    uint32_t D;
+    struct internal_state *state = strm->state;
+    uint32_t *restrict x = state->data_raw;
+    uint32_t *restrict d = state->data_pp;
+    uint32_t xmax = state->xmax;
+    uint32_t xmin = state->xmin;
+    uint32_t rsi = strm->rsi * strm->block_size - 1;
+    uint32_t m = UINT32_C(1) << (strm->bits_per_sample - 1);
+
+    state->ref = 1;
+    state->ref_sample = x[0];
+    d[0] = 0;
+    /* Sign extension */
+    x[0] = (x[0] ^ m) - m;
+
+    for (size_t i = 0; i < rsi; i++) {
+        x[i + 1] = (x[i + 1] ^ m) - m;
+        if ((int32_t)x[i + 1] < (int32_t)x[i]) {
+            D = x[i] - x[i + 1];
+            if (D <= xmax - x[i])
+                d[i + 1] = 2 * D - 1;
+            else
+                d[i + 1] = xmax - x[i + 1];
+        } else {
+            D = x[i + 1] - x[i];
+            if (D <= x[i] - xmin)
+                d[i + 1] = 2 * D;
+            else
+                d[i + 1] = x[i + 1] - xmin;
+        }
+    }
+    state->uncomp_len = (strm->block_size - 1) * strm->bits_per_sample;
+}
+
+static inline uint64_t block_fs(struct aec_stream *strm, int k)
+{
+    /**
+       Sum FS of all samples in block for given splitting position.
+    */
+
+    struct internal_state *state = strm->state;
+    uint64_t fs = 0;
+
+    for (size_t i = 0; i < strm->block_size; i++)
+        fs += (uint64_t)(state->block[i] >> k);
+
+    return fs;
+}
+
+static uint32_t assess_splitting_option(struct aec_stream *strm)
+{
+    /**
+       Length of CDS encoded with splitting option and optimal k.
+
+       In Rice coding each sample in a block of samples is split at
+       the same position into k LSB and bits_per_sample - k MSB. The
+       LSB part is left binary and the MSB part is coded as a
+       fundamental sequence a.k.a. unary (see CCSDS 121.0-B-3). The
+       function of the length of the Coded Data Set (CDS) depending on
+       k has exactly one minimum (see A. Kiely, IPN Progress Report
+       42-159).
+
+       To find that minimum with only a few costly evaluations of the
+       CDS length, we start with the k of the previous CDS. K is
+       increased and the CDS length evaluated. If the CDS length gets
+       smaller, then we are moving towards the minimum. If the length
+       increases, then the minimum will be found with smaller k.
+
+       For increasing k we know that we will gain block_size bits in
+       length through the larger binary part. If the FS length is less
+       than the block size then a reduced FS part can't compensate the
+       larger binary part. So we know that the CDS for k+1 will be
+       larger than for k without actually computing the length. An
+       analogue check can be done for decreasing k.
+     */
+
+    struct internal_state *state = strm->state;
+
+    /* Block size of current block */
+    uint64_t this_bs = strm->block_size - state->ref;
+
+    /* CDS length minimum so far */
+    uint64_t len_min = UINT64_MAX;
+
+    int k = state->k;
+    int k_min = k;
+
+    /* 1 if we shouldn't reverse */
+    int no_turn = (k == 0);
+
+    /* Direction, 1 means increasing k, 0 decreasing k */
+    int dir = 1;
+
+    for (;;) {
+        /* Length of FS part (not including 1s) */
+        uint64_t fs_len = block_fs(strm, k);
+
+        /* CDS length for current k */
+        uint64_t len = fs_len + this_bs * (k + 1);
+
+        if (len < len_min) {
+            if (len_min < UINT64_MAX)
+                no_turn = 1;
+
+            len_min = len;
+            k_min = k;
+
+            if (dir) {
+                if (fs_len < this_bs || k >= state->kmax) {
+                    if (no_turn)
+                        break;
+                    k = state->k - 1;
+                    dir = 0;
+                    no_turn = 1;
+                } else {
+                    k++;
+                }
+            } else {
+                if (fs_len >= this_bs || k == 0)
+                    break;
+                k--;
+            }
+        } else {
+            if (no_turn)
+                break;
+            k = state->k - 1;
+            dir = 0;
+            no_turn = 1;
+        }
+    }
+    state->k = k_min;
+
+    return (uint32_t)len_min;
+}
+
+static uint32_t assess_se_option(struct aec_stream *strm)
+{
+    /**
+       Length of CDS encoded with Second Extension option.
+
+       If length is above limit just return UINT32_MAX.
+    */
+
+    struct internal_state *state = strm->state;
+    uint32_t *block = state->block;
+    uint64_t len = 1;
+
+    for (size_t i = 0; i < strm->block_size; i += 2) {
+        uint64_t d = (uint64_t)block[i] + (uint64_t)block[i + 1];
+        len += d * (d + 1) / 2 + block[i + 1] + 1;
+        if (len > state->uncomp_len)
+            return UINT32_MAX;
+    }
+
+    return (uint32_t)len;
+}
+
+static void init_output(struct aec_stream *strm)
+{
+    /**
+       Direct output to next_out if next_out can hold a Coded Data
+       Set, use internal buffer otherwise.
+    */
+
+    struct internal_state *state = strm->state;
+
+    if (strm->avail_out > CDSLEN) {
+        if (!state->direct_out) {
+            state->direct_out = 1;
+            *strm->next_out = *state->cds;
+            state->cds = strm->next_out;
+        }
+    } else {
+        if (state->zero_blocks == 0 || state->direct_out) {
+            /* copy leftover from last block */
+            *state->cds_buf = *state->cds;
+            state->cds = state->cds_buf;
+        }
+        state->direct_out = 0;
+    }
+}
+
+/*
+ *
+ * FSM functions
+ *
+ */
+
+static int m_flush_block_resumable(struct aec_stream *strm)
+{
+    /**
+       Slow and restartable flushing
+    */
+    struct internal_state *state = strm->state;
+
+    int n = (int)MIN((size_t)(state->cds - state->cds_buf - state->i),
+                     strm->avail_out);
+    memcpy(strm->next_out, state->cds_buf + state->i, n);
+    strm->next_out += n;
+    strm->avail_out -= n;
+    state->i += n;
+
+    if (strm->avail_out == 0) {
+        return M_EXIT;
+    } else {
+        state->mode = m_get_block;
+        return M_CONTINUE;
+    }
+}
+
+static int m_flush_block(struct aec_stream *strm)
+{
+    /**
+       Flush block in direct_out mode by updating counters.
+
+       Fall back to slow flushing if in buffered mode.
+    */
+    struct internal_state *state = strm->state;
+
+#ifdef ENABLE_RSI_PADDING
+    if (state->blocks_avail == 0 &&
+        strm->flags & AEC_PAD_RSI &&
+        state->block_nonzero == 0)
+            emit(state, 0, state->bits % 8);
+#endif
+
+    if (state->direct_out) {
+        int n = (int)(state->cds - strm->next_out);
+        strm->next_out += n;
+        strm->avail_out -= n;
+        state->mode = m_get_block;
+
+        if (state->ready_to_capture_rsi &&
+            state->blocks_avail == 0 &&
+            state->offsets != NULL) {
+                vector_push_back(state->offsets, (strm->total_out - strm->avail_out) * 8 + (8 - state->bits));
+                state->ready_to_capture_rsi = 0;
+        }
+
+        return M_CONTINUE;
+    }
+
+    state->i = 0;
+    state->mode = m_flush_block_resumable;
+    return M_CONTINUE;
+}
+
+static int m_encode_splitting(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+    int k = state->k;
+
+    emit(state, k + 1, state->id_len);
+    if (state->ref)
+        emit(state, state->ref_sample, strm->bits_per_sample);
+
+    emitblock_fs(strm, k, state->ref);
+    if (k)
+        emitblock(strm, k, state->ref);
+
+    return m_flush_block(strm);
+}
+
+static int m_encode_uncomp(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    emit(state, (1U << state->id_len) - 1, state->id_len);
+    if (state->ref)
+        state->block[0] = state->ref_sample;
+    emitblock(strm, strm->bits_per_sample, 0);
+    return m_flush_block(strm);
+}
+
+static int m_encode_se(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    emit(state, 1, state->id_len + 1);
+    if (state->ref)
+        emit(state, state->ref_sample, strm->bits_per_sample);
+
+    for (size_t i = 0; i < strm->block_size; i+= 2) {
+        uint32_t d = state->block[i] + state->block[i + 1];
+        emitfs(state, d * (d + 1) / 2 + state->block[i + 1]);
+    }
+
+    return m_flush_block(strm);
+}
+
+static int m_encode_zero(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    emit(state, 0, state->id_len + 1);
+
+    if (state->zero_ref)
+        emit(state, state->zero_ref_sample, strm->bits_per_sample);
+
+    if (state->zero_blocks == ROS)
+        emitfs(state, 4);
+    else if (state->zero_blocks >= 5)
+        emitfs(state, state->zero_blocks);
+    else
+        emitfs(state, state->zero_blocks - 1);
+
+    state->zero_blocks = 0;
+    return m_flush_block(strm);
+}
+
+static int m_select_code_option(struct aec_stream *strm)
+{
+    /**
+       Decide which code option to use.
+    */
+
+    struct internal_state *state = strm->state;
+
+    uint32_t split_len;
+    uint32_t se_len;
+    if (state->id_len > 1)
+        split_len = assess_splitting_option(strm);
+    else
+        split_len = UINT32_MAX;
+    se_len = assess_se_option(strm);
+
+    if (split_len < state->uncomp_len) {
+        if (split_len < se_len)
+            return m_encode_splitting(strm);
+        else
+            return m_encode_se(strm);
+    } else {
+        if (state->uncomp_len <= se_len)
+            return m_encode_uncomp(strm);
+        else
+            return m_encode_se(strm);
+    }
+}
+
+static int m_check_zero_block(struct aec_stream *strm)
+{
+    /**
+       Check if input block is all zero.
+
+       Aggregate consecutive zero blocks until we find !0 or reach the
+       end of a segment or RSI.
+    */
+
+    struct internal_state *state = strm->state;
+    uint32_t *p = state->block;
+
+    size_t i;
+    for (i = 0; i < strm->block_size; i++)
+        if (p[i] != 0)
+            break;
+
+    if (i < strm->block_size) {
+        if (state->zero_blocks) {
+            /* The current block isn't zero but we have to emit a
+             * previous zero block first. The current block will be
+             * flagged and handled later.
+             */
+            state->block_nonzero = 1;
+            state->mode = m_encode_zero;
+            return M_CONTINUE;
+        }
+        state->mode = m_select_code_option;
+        return M_CONTINUE;
+    } else {
+        state->zero_blocks++;
+        if (state->zero_blocks == 1) {
+            state->zero_ref = state->ref;
+            state->zero_ref_sample = state->ref_sample;
+        }
+        if (state->blocks_avail == 0 || state->blocks_dispensed % 64 == 0) {
+            if (state->zero_blocks > 4)
+                state->zero_blocks = ROS;
+
+            state->mode = m_encode_zero;
+            return M_CONTINUE;
+        }
+        state->mode = m_get_block;
+        return M_CONTINUE;
+    }
+}
+
+static int m_get_rsi_resumable(struct aec_stream *strm)
+{
+    /**
+       Get RSI while input buffer is short.
+
+       Let user provide more input. Once we got all input, pad buffer
+       to full RSI.
+    */
+
+    struct internal_state *state = strm->state;
+
+    do {
+        if (strm->avail_in >= state->bytes_per_sample) {
+            state->data_raw[state->i] = state->get_sample(strm);
+        } else {
+            if (state->flush == AEC_FLUSH) {
+                if (state->i > 0) {
+                    state->blocks_avail = state->i / strm->block_size - 1;
+                    if (state->i % strm->block_size)
+                        state->blocks_avail++;
+                    /* Pad raw buffer with last sample. Only encode
+                     * blocks_avail will be encoded later. */
+                    do
+                        state->data_raw[state->i] =
+                            state->data_raw[state->i - 1];
+                    while(++state->i < strm->rsi * strm->block_size);
+                } else {
+                    /* Finish encoding by padding the last byte with
+                     * zero bits. */
+                    emit(state, 0, state->bits);
+                    if (strm->avail_out > 0) {
+                        if (!state->direct_out)
+                            *strm->next_out++ = *state->cds;
+                        strm->avail_out--;
+                        state->flushed = 1;
+                    }
+                    return M_EXIT;
+                }
+            } else {
+                return M_EXIT;
+            }
+        }
+    } while (++state->i < strm->rsi * strm->block_size);
+
+    if (strm->flags & AEC_DATA_PREPROCESS)
+        state->preprocess(strm);
+
+    return m_check_zero_block(strm);
+}
+
+static int m_get_block(struct aec_stream *strm)
+{
+    /**
+       Provide the next block of preprocessed input data.
+
+       Pull in a whole Reference Sample Interval (RSI) of data if
+       block buffer is empty.
+    */
+
+    struct internal_state *state = strm->state;
+
+    init_output(strm);
+
+    if (state->block_nonzero) {
+        state->block_nonzero = 0;
+        state->mode = m_select_code_option;
+        return M_CONTINUE;
+    }
+
+    if (state->blocks_avail == 0) {
+        state->blocks_avail = strm->rsi - 1;
+        state->block = state->data_pp;
+        state->blocks_dispensed = 1;
+        if (strm->avail_in >= state->rsi_len) {
+            state->ready_to_capture_rsi = 1;
+            state->get_rsi(strm);
+            if (strm->flags & AEC_DATA_PREPROCESS)
+                state->preprocess(strm);
+
+            return m_check_zero_block(strm);
+        } else {
+            state->i = 0;
+            state->mode = m_get_rsi_resumable;
+        }
+    } else {
+        if (state->ref) {
+            state->ref = 0;
+            state->uncomp_len = strm->block_size * strm->bits_per_sample;
+        }
+        state->block += strm->block_size;
+        state->blocks_dispensed++;
+        state->blocks_avail--;
+        return m_check_zero_block(strm);
+    }
+    return M_CONTINUE;
+}
+
+static void cleanup(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (strm->flags & AEC_DATA_PREPROCESS && state->data_raw)
+        free(state->data_raw);
+    if (state->data_pp)
+        free(state->data_pp);
+    free(state);
+}
+
+/*
+ *
+ * API functions
+ *
+ */
+
+int aec_encode_init(struct aec_stream *strm)
+{
+    struct internal_state *state;
+
+    if (strm->bits_per_sample > 32 || strm->bits_per_sample == 0)
+        return AEC_CONF_ERROR;
+
+    if (strm->flags & AEC_NOT_ENFORCE) {
+        /* All even block sizes are allowed. */
+        if (strm->block_size & 1)
+            return AEC_CONF_ERROR;
+    } else {
+        /* Only allow standard conforming block sizes */
+        if (strm->block_size != 8
+            && strm->block_size != 16
+            && strm->block_size != 32
+            && strm->block_size != 64)
+            return AEC_CONF_ERROR;
+    }
+
+    if (strm->rsi > 4096)
+        return AEC_CONF_ERROR;
+
+    state = malloc(sizeof(struct internal_state));
+    if (state == NULL)
+        return AEC_MEM_ERROR;
+
+    memset(state, 0, sizeof(struct internal_state));
+    strm->state = state;
+    state->uncomp_len = strm->block_size * strm->bits_per_sample;
+
+    if (strm->bits_per_sample > 16) {
+        /* 24/32 input bit settings */
+        state->id_len = 5;
+
+        if (strm->bits_per_sample <= 24
+            && strm->flags & AEC_DATA_3BYTE) {
+            state->bytes_per_sample = 3;
+            if (strm->flags & AEC_DATA_MSB) {
+                state->get_sample = aec_get_msb_24;
+                state->get_rsi = aec_get_rsi_msb_24;
+            } else {
+                state->get_sample = aec_get_lsb_24;
+                state->get_rsi = aec_get_rsi_lsb_24;
+            }
+        } else {
+            state->bytes_per_sample = 4;
+            if (strm->flags & AEC_DATA_MSB) {
+                state->get_sample = aec_get_msb_32;
+                state->get_rsi = aec_get_rsi_msb_32;
+            } else {
+                state->get_sample = aec_get_lsb_32;
+                state->get_rsi = aec_get_rsi_lsb_32;
+            }
+        }
+    }
+    else if (strm->bits_per_sample > 8) {
+        /* 16 bit settings */
+        state->id_len = 4;
+        state->bytes_per_sample = 2;
+
+        if (strm->flags & AEC_DATA_MSB) {
+            state->get_sample = aec_get_msb_16;
+            state->get_rsi = aec_get_rsi_msb_16;
+        } else {
+            state->get_sample = aec_get_lsb_16;
+            state->get_rsi = aec_get_rsi_lsb_16;
+        }
+    } else {
+        /* 8 bit settings */
+        if (strm->flags & AEC_RESTRICTED) {
+            if (strm->bits_per_sample <= 4) {
+                if (strm->bits_per_sample <= 2)
+                    state->id_len = 1;
+                else
+                    state->id_len = 2;
+            } else {
+                return AEC_CONF_ERROR;
+            }
+        } else {
+            state->id_len = 3;
+        }
+        state->bytes_per_sample = 1;
+
+        state->get_sample = aec_get_8;
+        state->get_rsi = aec_get_rsi_8;
+    }
+    state->rsi_len = strm->rsi * strm->block_size * state->bytes_per_sample;
+
+    if (strm->flags & AEC_DATA_SIGNED) {
+        state->xmax = (INT64_C(1) << (strm->bits_per_sample - 1)) - 1;
+        state->xmin = ~state->xmax;
+        state->preprocess = preprocess_signed;
+    } else {
+        state->xmax = (UINT64_C(1) << strm->bits_per_sample) - 1;
+        state->xmin = 0;
+        state->preprocess = preprocess_unsigned;
+    }
+
+    state->kmax = (1U << state->id_len) - 3;
+
+    state->data_pp = malloc(strm->rsi
+                            * strm->block_size
+                            * sizeof(uint32_t));
+    if (state->data_pp == NULL) {
+        cleanup(strm);
+        return AEC_MEM_ERROR;
+    }
+
+    if (strm->flags & AEC_DATA_PREPROCESS) {
+        state->data_raw = malloc(strm->rsi
+                                 * strm->block_size
+                                 * sizeof(uint32_t));
+        if (state->data_raw == NULL) {
+            cleanup(strm);
+            return AEC_MEM_ERROR;
+        }
+    } else {
+        state->data_raw = state->data_pp;
+    }
+
+    state->block = state->data_pp;
+
+    state->ref = 0;
+    strm->total_in = 0;
+    strm->total_out = 0;
+    state->flushed = 0;
+
+    state->cds = state->cds_buf;
+    *state->cds = 0;
+    state->bits = 8;
+    state->mode = m_get_block;
+    state->ready_to_capture_rsi = 0;
+    return AEC_OK;
+}
+
+int aec_encode(struct aec_stream *strm, int flush)
+{
+    /**
+       Finite-state machine implementation of the adaptive entropy
+       encoder.
+    */
+    struct internal_state *state = strm->state;
+
+    state->flush = flush;
+    strm->total_in += strm->avail_in;
+    strm->total_out += strm->avail_out;
+
+    while (state->mode(strm) == M_CONTINUE);
+
+    if (state->direct_out) {
+        int n = (int)(state->cds - strm->next_out);
+        strm->next_out += n;
+        strm->avail_out -= n;
+
+        *state->cds_buf = *state->cds;
+        state->cds = state->cds_buf;
+        state->direct_out = 0;
+    }
+    strm->total_in -= strm->avail_in;
+    strm->total_out -= strm->avail_out;
+    return AEC_OK;
+}
+
+int aec_encode_end(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    int status = AEC_OK;
+    if (state->flush == AEC_FLUSH && state->flushed == 0)
+        status = AEC_STREAM_ERROR;
+    if (state->offsets != NULL) {
+        vector_destroy(state->offsets);
+        state->offsets = NULL;
+    }
+    cleanup(strm);
+    return status;
+}
+
+int aec_encode_count_offsets(struct aec_stream *strm, size_t *count)
+{
+    struct internal_state *state = strm->state;
+    if (state->offsets == NULL) {
+        *count = 0;
+        return AEC_RSI_OFFSETS_ERROR;
+    } else {
+        *count = vector_size(state->offsets);
+    }
+    return AEC_OK;
+}
+
+int aec_encode_get_offsets(struct aec_stream *strm, size_t *offsets, size_t offsets_count)
+{
+    struct internal_state *state = strm->state;
+    if (state->offsets == NULL) {
+        return AEC_RSI_OFFSETS_ERROR;
+    }
+    if (offsets_count < vector_size(state->offsets)) {
+        return AEC_MEM_ERROR;
+    }
+    memcpy(offsets, vector_data(state->offsets), offsets_count * sizeof(size_t));
+    return AEC_OK;
+}
+
+int aec_encode_enable_offsets(struct aec_stream *strm)
+{
+    struct internal_state *state = strm->state;
+
+    if (state->offsets != NULL)
+        return AEC_RSI_OFFSETS_ERROR;
+
+    state->offsets = vector_create();
+    vector_push_back(state->offsets, 0);
+    return AEC_OK;
+}
+
+int aec_buffer_encode(struct aec_stream *strm)
+{
+    int status = aec_encode_init(strm);
+    if (status != AEC_OK)
+        return status;
+    status = aec_encode(strm, AEC_FLUSH);
+    if (status != AEC_OK) {
+        cleanup(strm);
+        return status;
+    }
+    return aec_encode_end(strm);
+}

--- a/c/src/encode_accessors.c
+++ b/c/src/encode_accessors.c
@@ -1,0 +1,234 @@
+/**
+ * @file encode_accessors.c
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Read various data types from input stream
+ *
+ */
+
+#include "config.h"
+#include "encode_accessors.h"
+#include "encode.h"
+#include "libaec.h"
+#include <stdint.h>
+#include <string.h>
+
+uint32_t aec_get_8(struct aec_stream *strm)
+{
+    strm->avail_in--;
+    return *strm->next_in++;
+}
+
+uint32_t aec_get_lsb_16(struct aec_stream *strm)
+{
+    uint32_t data = ((uint32_t)strm->next_in[1] << 8)
+        | (uint32_t)strm->next_in[0];
+
+    strm->next_in += 2;
+    strm->avail_in -= 2;
+    return data;
+}
+
+uint32_t aec_get_msb_16(struct aec_stream *strm)
+{
+    uint32_t data = ((uint32_t)strm->next_in[0] << 8)
+        | (uint32_t)strm->next_in[1];
+
+    strm->next_in += 2;
+    strm->avail_in -= 2;
+    return data;
+}
+
+uint32_t aec_get_lsb_24(struct aec_stream *strm)
+{
+    uint32_t data = ((uint32_t)strm->next_in[2] << 16)
+        | ((uint32_t)strm->next_in[1] << 8)
+        | (uint32_t)strm->next_in[0];
+
+    strm->next_in += 3;
+    strm->avail_in -= 3;
+    return data;
+}
+
+uint32_t aec_get_msb_24(struct aec_stream *strm)
+{
+    uint32_t data = ((uint32_t)strm->next_in[0] << 16)
+        | ((uint32_t)strm->next_in[1] << 8)
+        | (uint32_t)strm->next_in[2];
+
+    strm->next_in += 3;
+    strm->avail_in -= 3;
+    return data;
+}
+
+uint32_t aec_get_lsb_32(struct aec_stream *strm)
+{
+    uint32_t data = ((uint32_t)strm->next_in[3] << 24)
+        | ((uint32_t)strm->next_in[2] << 16)
+        | ((uint32_t)strm->next_in[1] << 8)
+        | (uint32_t)strm->next_in[0];
+
+    strm->next_in += 4;
+    strm->avail_in -= 4;
+    return data;
+}
+
+uint32_t aec_get_msb_32(struct aec_stream *strm)
+{
+    uint32_t data = ((uint32_t)strm->next_in[0] << 24)
+        | ((uint32_t)strm->next_in[1] << 16)
+        | ((uint32_t)strm->next_in[2] << 8)
+        | (uint32_t)strm->next_in[3];
+
+    strm->next_in += 4;
+    strm->avail_in -= 4;
+    return data;
+}
+
+void aec_get_rsi_8(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    unsigned const char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = (uint32_t)in[i];
+
+    strm->next_in += rsi;
+    strm->avail_in -= rsi;
+}
+
+void aec_get_rsi_lsb_16(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    const unsigned char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = (uint32_t)in[2 * i] | ((uint32_t)in[2 * i + 1] << 8);
+
+    strm->next_in += 2 * rsi;
+    strm->avail_in -= 2 * rsi;
+}
+
+void aec_get_rsi_msb_16(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    const unsigned char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = ((uint32_t)in[2 * i] << 8) | (uint32_t)in[2 * i + 1];
+
+    strm->next_in += 2 * rsi;
+    strm->avail_in -= 2 * rsi;
+}
+
+void aec_get_rsi_lsb_24(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    const unsigned char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = (uint32_t)in[3 * i]
+            | ((uint32_t)in[3 * i + 1] << 8)
+            | ((uint32_t)in[3 * i + 2] << 16);
+
+    strm->next_in += 3 * rsi;
+    strm->avail_in -= 3 * rsi;
+}
+
+void aec_get_rsi_msb_24(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    const unsigned char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = ((uint32_t)in[3 * i] << 16)
+            | ((uint32_t)in[3 * i + 1] << 8)
+            | (uint32_t)in[3 * i + 2];
+
+    strm->next_in += 3 * rsi;
+    strm->avail_in -= 3 * rsi;
+}
+
+#define AEC_GET_RSI_NATIVE_32(BO)                       \
+    void aec_get_rsi_##BO##_32(struct aec_stream *strm) \
+    {                                               \
+        int rsi = strm->rsi * strm->block_size;     \
+        memcpy(strm->state->data_raw,               \
+               strm->next_in, 4 * rsi);             \
+        strm->next_in += 4 * rsi;                   \
+        strm->avail_in -= 4 * rsi;                  \
+    }
+
+#ifdef WORDS_BIGENDIAN
+void aec_get_rsi_lsb_32(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    const unsigned char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = (uint32_t)in[4 * i]
+            | ((uint32_t)in[4 * i + 1] << 8)
+            | ((uint32_t)in[4 * i + 2] << 16)
+            | ((uint32_t)in[4 * i + 3] << 24);
+
+    strm->next_in += 4 * rsi;
+    strm->avail_in -= 4 * rsi;
+}
+
+AEC_GET_RSI_NATIVE_32(msb);
+
+#else /* !WORDS_BIGENDIAN */
+void aec_get_rsi_msb_32(struct aec_stream *strm)
+{
+    uint32_t *restrict out = strm->state->data_raw;
+    const unsigned char *restrict in = strm->next_in;
+    int rsi = strm->rsi * strm->block_size;
+
+    strm->next_in += 4 * rsi;
+    strm->avail_in -= 4 * rsi;
+
+    for (int i = 0; i < rsi; i++)
+        out[i] = ((uint32_t)in[4 * i] << 24)
+            | ((uint32_t)in[4 * i + 1] << 16)
+            | ((uint32_t)in[4 * i + 2] << 8)
+            | (uint32_t)in[4 * i + 3];
+}
+
+AEC_GET_RSI_NATIVE_32(lsb)
+
+#endif /* !WORDS_BIGENDIAN */

--- a/c/src/graec.c
+++ b/c/src/graec.c
@@ -1,0 +1,267 @@
+/**
+ * @file aec.c
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * CLI frontend for Adaptive Entropy Coding library
+ *
+ */
+
+#include <libaec.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHUNK 10485760
+
+int get_param(unsigned int *param, int *iarg, char *argv[])
+{
+    if (strlen(argv[*iarg]) == 2) {
+        (*iarg)++;
+        if (argv[*iarg][0] == '-')
+            return 1;
+        else
+            *param = atoi(argv[*iarg]);
+    } else {
+        *param = atoi(&argv[*iarg][2]);
+    }
+    return 0;
+}
+
+void usage(void)
+{
+    fprintf(stderr, "NAME\n\taec - encode or decode files ");
+    fprintf(stderr, "with Adaptive Entropy Coding\n\n");
+    fprintf(stderr, "SYNOPSIS\n\taec [OPTION]... SOURCE DEST\n");
+    fprintf(stderr, "\nOPTIONS\n");
+    fprintf(stderr, "\t-3\n\t\t24 bit samples are stored in 3 bytes\n");
+    fprintf(stderr, "\t-N\n\t\tdisable pre/post processing\n");
+    fprintf(stderr, "\t-b size\n\t\tinternal buffer size in bytes\n");
+    fprintf(stderr, "\t-d\n\t\tdecode SOURCE. If -d is not used: encode.\n");
+    fprintf(stderr, "\t-j samples\n\t\tblock size in samples\n");
+    fprintf(stderr, "\t-m\n\t\tsamples are MSB first. Default is LSB\n");
+    fprintf(stderr, "\t-n bits\n\t\tbits per sample\n");
+    fprintf(stderr, "\t-p\n\t\tpad RSI to byte boundary\n");
+    fprintf(stderr, "\t-r blocks\n\t\treference sample interval in blocks\n");
+    fprintf(stderr, "\t-s\n\t\tsamples are signed. Default is unsigned\n");
+    fprintf(stderr, "\t-t\n\t\tuse restricted set of code options\n\n");
+}
+
+int main(int argc, char *argv[])
+{
+    struct aec_stream strm;
+    unsigned char *in = NULL;
+    unsigned char *out = NULL;
+    size_t total_out;
+    unsigned int chunk;
+    int status = 0;
+    int input_avail, output_avail;
+    char *infn, *outfn;
+    FILE *infp, *outfp;
+    int dflag;
+    char *opt;
+    int iarg;
+
+    chunk = CHUNK;
+    strm.bits_per_sample = 8;
+    strm.block_size = 8;
+    strm.rsi = 2;
+    strm.flags = AEC_DATA_PREPROCESS;
+    dflag = 0;
+    iarg = 1;
+
+    while (iarg < argc - 2) {
+        opt = argv[iarg];
+        if (opt[0] != '-') {
+            usage();
+            goto DESTRUCT;
+        }
+        switch (opt[1]) {
+        case '3':
+            strm.flags |= AEC_DATA_3BYTE;
+            break;
+        case 'N':
+            strm.flags &= ~AEC_DATA_PREPROCESS;
+            break;
+        case 'b':
+            if (get_param(&chunk, &iarg, argv)) {
+                usage();
+                goto DESTRUCT;
+            }
+            break;
+        case 'd':
+            dflag = 1;
+            break;
+        case 'j':
+            if (get_param(&strm.block_size, &iarg, argv)) {
+                usage();
+                goto DESTRUCT;
+            }
+            break;
+        case 'm':
+            strm.flags |= AEC_DATA_MSB;
+            break;
+        case 'n':
+            if (get_param(&strm.bits_per_sample, &iarg, argv)) {
+                usage();
+                goto DESTRUCT;
+            }
+            break;
+        case 'p':
+            strm.flags |= AEC_PAD_RSI;
+            break;
+        case 'r':
+            if (get_param(&strm.rsi, &iarg, argv)) {
+                usage();
+                goto DESTRUCT;
+            }
+            break;
+        case 's':
+            strm.flags |= AEC_DATA_SIGNED;
+            break;
+        case 't':
+            strm.flags |= AEC_RESTRICTED;
+            break;
+        default:
+            usage();
+            goto DESTRUCT;
+        }
+        iarg++;
+    }
+
+    if (argc - iarg < 2) {
+        usage();
+        goto DESTRUCT;
+    }
+
+    infn = argv[iarg];
+    outfn = argv[iarg + 1];
+
+    if (strm.bits_per_sample > 16) {
+        if (strm.bits_per_sample <= 24 && strm.flags & AEC_DATA_3BYTE)
+            chunk *= 3;
+        else
+            chunk *= 4;
+    } else if (strm.bits_per_sample > 8) {
+        chunk *= 2;
+    }
+
+    out = (unsigned char *)malloc(chunk);
+    in = (unsigned char *)malloc(chunk);
+
+    if (in == NULL || out == NULL) {
+        status = 99;
+        goto DESTRUCT;
+    }
+
+    total_out = 0;
+    strm.avail_in = 0;
+    strm.avail_out = chunk;
+    strm.next_out = out;
+
+    input_avail = 1;
+    output_avail = 1;
+
+    if ((infp = fopen(infn, "rb")) == NULL) {
+        fprintf(stderr, "ERROR: cannot open input file %s\n", infn);
+        status = 99;
+        goto DESTRUCT;
+    }
+    if ((outfp = fopen(outfn, "wb")) == NULL) {
+        fprintf(stderr, "ERROR: cannot open output file %s\n", infn);
+        status = 99;
+        goto DESTRUCT;
+    }
+
+    if (dflag)
+        status = aec_decode_init(&strm);
+    else
+        status = aec_encode_init(&strm);
+
+    if (status != AEC_OK) {
+        fprintf(stderr, "ERROR: initialization failed (%d)\n", status);
+        goto DESTRUCT;
+    }
+
+    while(input_avail || output_avail) {
+        if (strm.avail_in == 0 && input_avail) {
+            strm.avail_in = fread(in, 1, chunk, infp);
+            if (strm.avail_in != chunk)
+                input_avail = 0;
+            strm.next_in = in;
+        }
+
+        if (dflag)
+            status = aec_decode(&strm, AEC_NO_FLUSH);
+        else
+            status = aec_encode(&strm, AEC_NO_FLUSH);
+
+        if (status != AEC_OK) {
+            fprintf(stderr, "ERROR: %i\n", status);
+            goto DESTRUCT;
+        }
+
+        if (strm.total_out - total_out > 0) {
+            fwrite(out, strm.total_out - total_out, 1, outfp);
+            total_out = strm.total_out;
+            output_avail = 1;
+            strm.next_out = out;
+            strm.avail_out = chunk;
+        } else {
+            output_avail = 0;
+        }
+
+    }
+
+    if (dflag) {
+        aec_decode_end(&strm);
+    } else {
+        if ((status = aec_encode(&strm, AEC_FLUSH)) != AEC_OK) {
+            fprintf(stderr, "ERROR: while flushing output (%i)\n", status);
+            goto DESTRUCT;
+        }
+
+        if (strm.total_out - total_out > 0)
+            fwrite(out, strm.total_out - total_out, 1, outfp);
+
+        aec_encode_end(&strm);
+    }
+
+    fclose(infp);
+    fclose(outfp);
+
+DESTRUCT:
+    if (in)
+        free(in);
+    if (out)
+        free(out);
+    return status;
+}

--- a/c/src/graec.c
+++ b/c/src/graec.c
@@ -34,7 +34,7 @@
  * CLI frontend for Adaptive Entropy Coding library
  *
  */
-
+/*
 #include <libaec.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -265,3 +265,4 @@ DESTRUCT:
         free(out);
     return status;
 }
+*/

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -105,6 +105,13 @@ uint8_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompressio
             return om_get_bytes_per_element(data_type, error);
         case COMPRESSION_PFOR_DELTA2D:
             return om_get_bytes_per_element(data_type, error);
+            
+        case COMPRESSION_AEC:
+            if (data_type != DATA_TYPE_FLOAT_ARRAY) {
+                *error = ERROR_INVALID_DATA_TYPE;
+                break;
+            }
+            return 2;
 
         default:
             *error = ERROR_INVALID_COMPRESSION_TYPE;

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -225,9 +225,9 @@ ALWAYS_INLINE uint64_t om_decode_decompress(
                 assert(0);
                 return -99;
             }
-            aec_decode_end(&strm);
             result = data_size;
-            printf("decoder strm.total_out %zu\n", strm.total_out);
+            //printf("decoder strm.total_out %zu\n", strm.total_out);
+            aec_decode_end(&strm);
             break;
         }
     }
@@ -284,8 +284,8 @@ ALWAYS_INLINE void om_decode_filter(
         case COMPRESSION_NONE:
             break;
         case COMPRESSION_AEC:
-            assert(data_type == DATA_TYPE_FLOAT_ARRAY && "Expecting float array");
-            delta2d_decode16((size_t)(length_in_chunk / length_last), (size_t)length_last, (int16_t*)data);
+            //assert(data_type == DATA_TYPE_FLOAT_ARRAY && "Expecting float array");
+            //delta2d_decode16((size_t)(length_in_chunk / length_last), (size_t)length_last, (int16_t*)data);
             break;
     }
 }

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -157,16 +157,24 @@ ALWAYS_INLINE uint64_t om_encode_compress(
             if (aec_encode_init(&strm) != AEC_OK)
                 return 1;
 
+            /*if (aec_encode_enable_offsets(&strm) != AEC_OK)
+                return 1;*/
+
             /* Perform encoding in one call and flush output. */
             /* In this example you must be sure that the output */
             /* buffer is large enough for all compressed output */
             if (aec_encode(&strm, AEC_FLUSH) != AEC_OK)
                 return 1;
+            
+            /*size_t count_offsets;
+            if (aec_encode_count_offsets(&strm, &count_offsets) != AEC_OK)
+                return 1;
+            printf("count_offsets %zu\n", count_offsets);*/
 
             /* free all resources used by encoder */
-            aec_encode_end(&strm);
             result = strm.total_out;
-            printf("strm.total_out %zu\n", strm.total_out);
+            aec_encode_end(&strm);
+            //printf("strm.total_out %zu\n", strm.total_out);
             break;
         }
     }
@@ -226,8 +234,8 @@ ALWAYS_INLINE void om_encode_filter(
             break;
         case COMPRESSION_AEC:
             // The initializer should have ensured that the data type is float
-            assert(data_type == DATA_TYPE_FLOAT_ARRAY && "Expecting float array");
-            delta2d_encode16((size_t)(length_in_chunk / length_last), (size_t)length_last, (int16_t*)data);
+            //assert(data_type == DATA_TYPE_FLOAT_ARRAY && "Expecting float array");
+            //delta2d_encode16((size_t)(length_in_chunk / length_last), (size_t)length_last, (int16_t*)data);
             break;
     }
 }

--- a/c/src/sz_compat.c
+++ b/c/src/sz_compat.c
@@ -1,0 +1,296 @@
+/**
+ * @file sz_compat.c
+ *
+ * @section LICENSE
+ * Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ *
+ * Adaptive Entropy Coding library
+ *
+ */
+
+#include "config.h"
+#include "szlib.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NOPTS 129
+#define MIN(a, b) (((a) < (b))? (a): (b))
+
+static int convert_options(int sz_opts)
+{
+    int co[NOPTS];
+    int opts = 0;
+
+    memset(co, 0, sizeof(int) * NOPTS);
+    co[SZ_MSB_OPTION_MASK] = AEC_DATA_MSB;
+    co[SZ_NN_OPTION_MASK] = AEC_DATA_PREPROCESS;
+
+    for (int i = 1; i < NOPTS; i <<= 1)
+        if (sz_opts & i)
+            opts |= co[i];
+
+    return opts;
+}
+
+static int bits_to_bytes(int bit_length)
+{
+    if (bit_length > 16)
+        return 4;
+    else if (bit_length > 8)
+        return 2;
+    else
+        return 1;
+}
+
+static void interleave_buffer(void *dest, const void *src,
+                              size_t n, size_t wordsize)
+{
+    const unsigned char *src8 = (unsigned char *)src;
+    unsigned char *dest8 = (unsigned char *)dest;
+
+    for (size_t i = 0; i < n / wordsize; i++)
+        for (size_t j = 0; j < wordsize; j++)
+            dest8[j * (n / wordsize) + i] = src8[i * wordsize + j];
+}
+
+static void deinterleave_buffer(void *dest, const void *src,
+                                size_t n, size_t wordsize)
+{
+    const unsigned char *src8 = (unsigned char *)src;
+    unsigned char *dest8 = (unsigned char *)dest;
+
+    for (size_t i = 0; i < n / wordsize; i++)
+        for (size_t j = 0; j < wordsize; j++)
+            dest8[i * wordsize + j] = src8[j * (n / wordsize) + i];
+}
+
+static void add_padding(void *dest, const void *src, size_t src_length,
+                        size_t line_size, size_t padding_size,
+                        int pixel_size, int pp)
+{
+    const char zero_pixel[] = {0, 0, 0, 0};
+
+    const char *pixel = zero_pixel;
+    size_t j = 0;
+    size_t i = 0;
+    while (i < src_length) {
+        size_t ps;
+        size_t ls = MIN(src_length - i, line_size);
+        memcpy((char *)dest + j, (char *)src + i, ls);
+        j += ls;
+        i += ls;
+        if (pp)
+            pixel = (char *)src + i - pixel_size;
+        ps = line_size + padding_size - ls;
+        for (size_t k = 0; k < ps; k += pixel_size)
+            memcpy((char *)dest + j + k, pixel, pixel_size);
+        j += ps;
+    }
+}
+
+static void remove_padding(void *buf, size_t buf_length,
+                           size_t line_size, size_t padding_size,
+                           int pixel_size)
+{
+    size_t padded_line_size = line_size + padding_size;
+
+    size_t i = line_size;
+    for (size_t j = padded_line_size; j < buf_length; j += padded_line_size) {
+        memmove((char *)buf + i, (char *)buf + j, line_size);
+        i += line_size;
+    }
+}
+
+int SZ_BufftoBuffCompress(void *dest, size_t *destLen,
+                          const void *source, size_t sourceLen,
+                          SZ_com_t *param)
+{
+    struct aec_stream strm;
+    void *buf = 0;
+    void *padbuf = 0;
+    int status;
+    int interleave;
+    int pixel_size;
+    int aec_status;
+    size_t scanlines;
+    size_t padbuf_size;
+    size_t padding_size;
+
+    strm.block_size = param->pixels_per_block;
+    strm.rsi = (param->pixels_per_scanline + param->pixels_per_block - 1)
+        / param->pixels_per_block;
+    strm.flags = AEC_NOT_ENFORCE | convert_options(param->options_mask);
+    strm.avail_out = *destLen;
+    strm.next_out = dest;
+
+    interleave = param->bits_per_pixel == 32 || param->bits_per_pixel == 64;
+    if (interleave) {
+        strm.bits_per_sample = 8;
+        buf = malloc(sourceLen);
+        if (buf == NULL) {
+            status = SZ_MEM_ERROR;
+            goto CLEANUP;
+        }
+        interleave_buffer(buf, source, sourceLen, param->bits_per_pixel / 8);
+    } else {
+        strm.bits_per_sample = param->bits_per_pixel;
+        buf = (void *)source;
+    }
+
+    pixel_size = bits_to_bytes(strm.bits_per_sample);
+
+    scanlines = (sourceLen / pixel_size + param->pixels_per_scanline - 1)
+        / param->pixels_per_scanline;
+    padbuf_size = strm.rsi * strm.block_size * pixel_size * scanlines;
+    padbuf = malloc(padbuf_size);
+    if (padbuf == NULL) {
+        status = SZ_MEM_ERROR;
+        goto CLEANUP;
+    }
+
+    padding_size =
+        (strm.rsi * strm.block_size - param->pixels_per_scanline)
+        * pixel_size;
+
+    add_padding(padbuf, buf, sourceLen,
+                param->pixels_per_scanline * pixel_size,
+                padding_size, pixel_size,
+                strm.flags & AEC_DATA_PREPROCESS);
+    strm.next_in = padbuf;
+    strm.avail_in = padbuf_size;
+
+    aec_status = aec_buffer_encode(&strm);
+    if (aec_status == AEC_STREAM_ERROR)
+        status = SZ_OUTBUFF_FULL;
+    else
+        status = aec_status;
+    *destLen = strm.total_out;
+
+CLEANUP:
+    if (padbuf)
+        free(padbuf);
+    if (interleave && buf)
+        free(buf);
+    return status;
+}
+
+int SZ_BufftoBuffDecompress(void *dest, size_t *destLen,
+                            const void *source, size_t sourceLen,
+                            SZ_com_t *param)
+{
+    struct aec_stream strm;
+    void *buf = 0;
+    int status;
+    int pad_scanline;
+    int deinterleave;
+    int extra_buffer;
+    int pixel_size;
+    size_t total_out;
+    size_t scanlines;
+
+    strm.block_size = param->pixels_per_block;
+    strm.rsi = (param->pixels_per_scanline + param->pixels_per_block - 1)
+        / param->pixels_per_block;
+    strm.flags = convert_options(param->options_mask);
+    strm.avail_in = sourceLen;
+    strm.next_in = source;
+
+    pad_scanline = param->pixels_per_scanline % param->pixels_per_block;
+    deinterleave = (param->bits_per_pixel == 32
+                        || param->bits_per_pixel == 64);
+    extra_buffer = pad_scanline || deinterleave;
+
+    if (deinterleave)
+        strm.bits_per_sample = 8;
+    else
+        strm.bits_per_sample = param->bits_per_pixel;
+    pixel_size = bits_to_bytes(strm.bits_per_sample);
+
+
+    if (extra_buffer) {
+        size_t buf_size;
+        if (pad_scanline) {
+            scanlines = (*destLen / pixel_size + param->pixels_per_scanline - 1)
+                / param->pixels_per_scanline;
+            buf_size = strm.rsi * strm.block_size * pixel_size * scanlines;
+        } else {
+            buf_size = *destLen;
+        }
+        buf = malloc(buf_size);
+        if (buf == NULL) {
+            status = SZ_MEM_ERROR;
+            goto CLEANUP;
+        }
+        strm.next_out = buf;
+        strm.avail_out = buf_size;
+    } else {
+        strm.next_out = dest;
+        strm.avail_out = *destLen;
+    }
+
+    status = aec_buffer_decode(&strm);
+    if (status != AEC_OK)
+        goto CLEANUP;
+
+    if (pad_scanline) {
+        size_t padding_size =
+            (strm.rsi * strm.block_size - param->pixels_per_scanline)
+            * pixel_size;
+        remove_padding(buf, strm.total_out,
+                       param->pixels_per_scanline * pixel_size,
+                       padding_size, pixel_size);
+        total_out = scanlines * param->pixels_per_scanline * pixel_size;
+    } else {
+        total_out = strm.total_out;
+    }
+
+    if (total_out < *destLen)
+        *destLen = total_out;
+
+    if (deinterleave)
+        deinterleave_buffer(dest, buf, *destLen, param->bits_per_pixel / 8);
+    else if (pad_scanline)
+        memcpy(dest, buf, *destLen);
+
+CLEANUP:
+    if (extra_buffer && buf)
+        free(buf);
+
+    return status;
+}
+
+int SZ_encoder_enabled(void)
+{
+    return 1;
+}
+
+/* netcdf searches for SZ_Compress in configure */
+char SZ_Compress() { return SZ_OK; }

--- a/c/src/vector.c
+++ b/c/src/vector.c
@@ -1,0 +1,68 @@
+#include "vector.h"
+#include <stdio.h>
+
+#define VECTOR_INITIAL_CAPACITY 128
+#define VECTOR_GROWTH_FACTOR 2
+
+#define VECTOR_FATAL_ERROR(...) \
+  { \
+    fprintf(stderr, "Fatal error in %s at line %d: Exiting", __FILE__, __LINE__); \
+    exit(1); \
+  }
+
+struct vector_t* vector_create()
+{
+  struct vector_t *vec = malloc(sizeof(struct vector_t));
+  if (vec == NULL)
+    VECTOR_FATAL_ERROR("Failed to allocate memory for vector\n");
+
+  vec->capacity = VECTOR_INITIAL_CAPACITY;
+  vec->size = 0;
+  vec->values = malloc(sizeof(*vec->values) * vec->capacity);
+  if (vec->values == NULL)
+    VECTOR_FATAL_ERROR("Failed to allocate memory for vector values\n");
+  return vec;
+}
+
+size_t vector_size(struct vector_t* vec)
+{
+  return vec->size;
+}
+
+void vector_destroy(struct vector_t *vec)
+{
+  free(vec->values);
+  free(vec);
+}
+
+int vector_equal(struct vector_t *vec1, struct vector_t *vec2)
+{
+  if (vec1->size != vec2->size)
+    return 0;
+  for (size_t i = 0; i < vec1->size; i++)
+    if (vec1->values[i] != vec2->values[i])
+      return 0;
+  return 1;
+}
+
+size_t vector_at(struct vector_t *vector, size_t idx)
+{
+  return vector->values[idx];
+}
+
+void vector_push_back(struct vector_t *vec, size_t value)
+{
+  if (vec->size == vec->capacity) {
+    vec->capacity *= VECTOR_GROWTH_FACTOR;
+    vec->values = realloc(vec->values, sizeof(*vec->values) * vec->capacity);
+    if (vec->values == NULL)
+      VECTOR_FATAL_ERROR("Failed to reallocate memory for vector values\n");
+  }
+  vec->values[vec->size] = value;
+  vec->size++;
+}
+
+size_t* vector_data(struct vector_t *vec)
+{
+  return vec->values;
+}


### PR DESCRIPTION
https://gitlab.dkrz.de/k202009/libaec

Also used in GRIB2 CCSDS and replaced szip in HDF5/NetCDF. Although it is available in HDF5, the chunking overhead of HDF5 is >15% (chunks [32,32]) which makes any gains in compression ratio useless.

For testing, I added LibAEC to om-files and used a single temperature 2m field in ECMWF IFS0.25. Compression ratio 580 KB vs 669 KB. 

Compared to the existing 2d delta coded Pfor, 15% smaller compressed size, but 2x slower compression speed and 6x slower decompression speed.

benchmarks:
```
AEC
Wrote 3.96 MB elements in 0.009100625 seconds, 435.1977242291052 MB/s
Read 3.96 MB elements in 0.0075075 seconds, 527.5486232517483 MB/s
Wrote 3.96 MB elements in 0.008896042 seconds, 445.2060016198777 MB/s
Read 3.96 MB elements in 0.007659209 seconds, 517.0992577774676 MB/s
Wrote 3.96 MB elements in 0.008969458 seconds, 441.56194154234294 MB/s
Read 3.96 MB elements in 0.008229583 seconds, 481.2602642275435 MB/s
Wrote 3.96 MB elements in 0.00836925 seconds, 473.2289379648714 MB/s
Read 3.96 MB elements in 0.007385875 seconds, 536.2358947399597 MB/s
Wrote 3.96 MB elements in 0.008725666 seconds, 453.8990249068094 MB/s
Read 3.96 MB elements in 0.007397375 seconds, 535.4022594585917 MB/s

Pfor
Wrote 3.96 MB elements in 0.010580375 seconds, 374.33184448211904 MB/s
Read 3.96 MB elements in 0.001333917 seconds, 2969.1287306950135 MB/s
Wrote 3.96 MB elements in 0.003704833 seconds, 1069.0282906307789 MB/s
Read 3.96 MB elements in 0.001164708 seconds, 3400.484318011467 MB/s
Wrote 3.96 MB elements in 0.00419575 seconds, 943.9483498927486 MB/s
Read 3.96 MB elements in 0.001383916 seconds, 2861.8581540082637 MB/s
Wrote 3.96 MB elements in 0.003892667 seconds, 1017.4441556553644 MB/s
Read 3.96 MB elements in 0.00123975 seconds, 3194.65318738657 MB/s
Wrote 3.96 MB elements in 0.003992708 seconds, 991.9511492106359 MB/s
Read 3.96 MB elements in 0.001206 seconds, 3284.055795242537 MB/s
Wrote 3.96 MB elements in 0.003618375 seconds, 1094.5718144367293 MB/s
Read 3.96 MB elements in 0.001131459 seconds, 3500.410787366135 MB/s
Wrote 3.96 MB elements in 0.003685375 seconds, 1074.6725337482617 MB/s
Read 3.96 MB elements in 0.0012775 seconds, 3100.2514982876714 MB/s
```