### PR TITLE
feat: test integration of lz4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "c/external/lz4"]
+	path = c/external/lz4
+	url = https://github.com/lz4/lz4.git

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let swiftFlags: [PackageDescription.SwiftSetting] = [
 
 // Note: Fast math flags reduce performance for compression
 let cFlagsPFor2D = [PackageDescription.CSetting.unsafeFlags(["-O3"] + mArch)]
-let cFlagsPFor = [PackageDescription.CSetting.unsafeFlags(["-O3", "-Wall", "-Werror", "-Wimplicit-fallthrough", "-Wextra"] + mArch)]
+let cFlagsPFor = [PackageDescription.CSetting.unsafeFlags(["-O3", "-Wall", "-Werror", "-Wextra"] + mArch)]
 
 
 let package = Package(
@@ -40,7 +40,15 @@ let package = Package(
         .target(
             name: "OmFileFormatC",
             path: "c",
-            cSettings: cFlagsPFor,
+            sources: [
+                "src",
+                "external/lz4/lib/lz4.c",
+            ],
+            cSettings: cFlagsPFor + [
+                .headerSearchPath("external/lz4/lib"),
+                .define("LZ4"),
+                .unsafeFlags(["-Iexternal/lz4/lib"])
+            ],
             swiftSettings: swiftFlags
         ),
         .testTarget(

--- a/Swift/OmFileFormat/OmBufferedWriter.swift
+++ b/Swift/OmFileFormat/OmBufferedWriter.swift
@@ -40,9 +40,9 @@ public final class OmBufferedWriter<FileHandle: OmFileWriterBackend> {
     }
 
     /// Add empty space if required to align to 64 bits
-    func alignTo64Bytes() throws {
+    func alignTo8Bytes() throws {
         let bytesToPadd = 8 - totalBytesWritten % 8
-        if bytesToPadd == 0 {
+        if bytesToPadd == 8 {
             return
         }
         try reallocate(minimumCapacity: bytesToPadd)

--- a/Swift/OmFileFormat/OmFileDataTypeProtocol.swift
+++ b/Swift/OmFileFormat/OmFileDataTypeProtocol.swift
@@ -135,3 +135,9 @@ extension Double: OmFileScalarDataTypeProtocol {
         return .double
     }
 }
+
+extension String: OmFileScalarDataTypeProtocol {
+    public static var dataTypeScalar: DataType {
+        return .string
+    }
+}

--- a/Swift/OmFileFormat/OmFileFormat.swift
+++ b/Swift/OmFileFormat/OmFileFormat.swift
@@ -63,8 +63,11 @@ public enum CompressionType: UInt8, Codable {
     /// PFor integer compression. Floating point values are scaled to 32 bit signed integers. Doubles are scaled to 64 bit signed integers.
     case pfor_delta2d = 2
 
-    ///  Similar to `pfor_delta2d_int16` but applies `log10(1+x)` before
+    /// Similar to `pfor_delta2d_int16` but applies `log10(1+x)` before
     case pfor_delta2d_int16_logarithmic = 3
+
+    /// No compression, currently only supported for string data
+    case none = 255
 
     func toC() -> OmCompression_t {
         switch self {
@@ -76,6 +79,8 @@ public enum CompressionType: UInt8, Codable {
             return COMPRESSION_PFOR_DELTA2D
         case .pfor_delta2d_int16_logarithmic:
             return COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC
+        case .none:
+            return COMPRESSION_NONE
         }
     }
 }

--- a/Swift/OmFileFormat/OmFileReader.swift
+++ b/Swift/OmFileFormat/OmFileReader.swift
@@ -121,7 +121,7 @@ public struct OmFileReader<Backend: OmFileReaderBackend> {
 
     /// Convert to string array reader if the variable is a string array
     public func asStringArray(io_size_max: UInt64 = 65536, io_size_merge: UInt64 = 512) -> OmFileReaderStringArray<Backend>? {
-        guard dataType == .string_array else {
+        guard self.dataType == .string_array else {
             return nil
         }
 
@@ -497,7 +497,7 @@ extension OmFileReaderBackend {
             /// The size to decode a single chunk
             let bufferSize = om_decoder_read_buffer_size(decoder)
 
-            /// Loop over index blocks and read index data
+            // Loop over index blocks and read index data
             while om_decoder_next_index_read(decoder, &indexRead) {
                 //print("Read index \(indexRead)")
                 let indexData = self.getData(offset: Int(indexRead.offset), count: Int(indexRead.count))
@@ -506,7 +506,7 @@ extension OmFileReaderBackend {
                 om_decoder_init_data_read(&dataRead, &indexRead)
 
                 var error: OmError_t = ERROR_OK
-                /// Loop over data blocks and read compressed data chunks
+                // Loop over data blocks and read compressed data chunks
                 while om_decoder_next_data_read(decoder, &dataRead, indexData, indexRead.count, &error) {
                     //print("ENQUEUE chunk index \(dataRead.chunkIndex)")
                     let dataReadOffset = dataRead.offset

--- a/Swift/OmFileFormat/OmFileWriter.swift
+++ b/Swift/OmFileFormat/OmFileWriter.swift
@@ -208,13 +208,6 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
         self.scale_factor = scale_factor
         self.add_offset = add_offset
 
-        if OmType.dataTypeArray == .string_array {
-            // string arrays need to have chunk dimensions of 1
-            if !chunkDimensions.allSatisfy({ $0 == 1 }) {
-                throw OmFileFormatSwiftError.omEncoder(error: "String arrays need to have chunk dimensions of 1")
-            }
-        }
-
         // Note: The encoder keeps the pointer to `&self.dimensions`. It is important that this array is not deallocated!
         self.encoder = OmEncoder_t()
         let error = om_encoder_init(&encoder, scale_factor, add_offset, compression.toC(), OmType.dataTypeArray.toC(), &self.dimensions, &self.chunks, UInt64(dimensions.count))
@@ -428,12 +421,12 @@ public final class OmFileWriterStringArray<FileHandle: OmFileWriterBackend> {
         buffer.incrementWritePosition(by: lutSize)
 
         return OmFileWriterArrayFinalised(
-            scale_factor: 0, // these are fake entries we don't really need, but wasting 4 bytes is fine
-            add_offset: 0, // these are fake entries we don't really need, but wasting 4 bytes is fine
+            scale_factor: 0, // these are fake entries we don't need, will not be written to the file for string arrays
+            add_offset: 0, // these are fake entries we don't need, will not be written to the file for string arrays
             compression: .none,
             datatype: .string_array,
             dimensions: dimensions,
-            chunks: dimensions.map { _ in 1 },  // one string per chunk
+            chunks: [], // this is a fake entry we don't need, will not be written to the file for string arrays
             lutSize: UInt64(lutSize),
             lutOffset: UInt64(lutOffset)
         )

--- a/Swift/OmFileFormat/OmFileWriter.swift
+++ b/Swift/OmFileFormat/OmFileWriter.swift
@@ -225,7 +225,7 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
         /// How many chunks can be written to the output. This could be only a single one, or multiple
         let numberOfChunksInArray = om_encoder_count_chunks_in_array(&encoder, arrayCount)
 
-        /// Store data start address if this is the first time this read is called
+        // Store data start address if this is the first time this read is called
         if self.chunkIndex == 0 {
             lookUpTable[chunkIndex] = UInt64(buffer.totalBytesWritten)
         }

--- a/Swift/OmFileFormat/OmFileWriter.swift
+++ b/Swift/OmFileFormat/OmFileWriter.swift
@@ -12,11 +12,11 @@ import Foundation
 /// Writes om file header and trailer
 public struct OmFileWriter<FileHandle: OmFileWriterBackend> {
     let buffer: OmBufferedWriter<FileHandle>
-    
+
     public init(fn: FileHandle, initialCapacity: Int) {
         self.buffer = OmBufferedWriter(backend: fn, initialCapacity: initialCapacity)
     }
-    
+
     public func writeHeaderIfRequired() throws {
         if buffer.totalBytesWritten > 0 {
             return
@@ -27,7 +27,7 @@ public struct OmFileWriter<FileHandle: OmFileWriterBackend> {
         om_header_write(buffer.bufferAtWritePosition)
         buffer.incrementWritePosition(by: size)
     }
-    
+
     public func write<OmType: OmFileScalarDataTypeProtocol>(value: OmType, name: String, children: [OmOffsetSize]) throws -> OmOffsetSize {
         try writeHeaderIfRequired()
         var name = name
@@ -36,25 +36,49 @@ public struct OmFileWriter<FileHandle: OmFileWriterBackend> {
             guard children.count <= UInt32.max else { fatalError() }
             let type = OmType.dataTypeScalar.toC()
             try buffer.alignTo64Bytes()
-            let size = om_variable_write_scalar_size(UInt16(name.count), UInt32(children.count), type)
+
+            let stringLength: UInt16
+            if type == DATA_TYPE_STRING {
+                // For strings, pass the string length
+                stringLength = UInt16((value as! String).utf8.count) // TODO: safely init?
+            } else {
+                stringLength = 0
+            }
+            let size = om_variable_write_scalar_size(
+                UInt16(name.count),
+                UInt32(children.count),
+                type,
+                stringLength
+            )
+
             let offset = UInt64(buffer.totalBytesWritten)
             try buffer.reallocate(minimumCapacity: Int(size))
             var value = value
             withUnsafePointer(to: &value, { value in
                 let childrenOffsets = children.map {$0.offset}
                 let childrenSizes = children.map {$0.size}
-                om_variable_write_scalar(buffer.bufferAtWritePosition, UInt16(name.count), UInt32(children.count), childrenOffsets, childrenSizes, name.baseAddress, type, value)
+                om_variable_write_scalar(
+                    buffer.bufferAtWritePosition,
+                    UInt16(name.count),
+                    UInt32(children.count),
+                    childrenOffsets,
+                    childrenSizes,
+                    name.baseAddress,
+                    type,
+                    value,
+                    stringLength
+                )
             })
             buffer.incrementWritePosition(by: size)
             return OmOffsetSize(offset: offset, size: UInt64(size))
         }
     }
-    
+
     public func prepareArray<OmType: OmFileArrayDataTypeProtocol>(type: OmType.Type, dimensions: [UInt64], chunkDimensions: [UInt64], compression: CompressionType, scale_factor: Float, add_offset: Float) throws -> OmFileWriterArray<OmType, FileHandle> {
         try writeHeaderIfRequired()
         return try .init(dimensions: dimensions, chunkDimensions: chunkDimensions, compression: compression, scale_factor: scale_factor, add_offset: add_offset, buffer: buffer)
     }
-    
+
     public func write(array: OmFileWriterArrayFinalised, name: String, children: [OmOffsetSize]) throws -> OmOffsetSize {
         try writeHeaderIfRequired()
         guard array.dimensions.count == array.chunks.count else {
@@ -74,17 +98,17 @@ public struct OmFileWriter<FileHandle: OmFileWriterBackend> {
             return OmOffsetSize(offset: offset, size: UInt64(size))
         }
     }
-    
+
     public func writeTrailer(rootVariable: OmOffsetSize) throws {
         try writeHeaderIfRequired()
         try buffer.alignTo64Bytes()
-        
+
         // write length of JSON
         let size = om_trailer_size()
         try buffer.reallocate(minimumCapacity: size)
         om_trailer_write(buffer.bufferAtWritePosition, rootVariable.offset, rootVariable.size)
         buffer.incrementWritePosition(by: size)
-        
+
         // Flush
         try buffer.writeToFile()
     }
@@ -94,71 +118,71 @@ public struct OmFileWriter<FileHandle: OmFileWriterBackend> {
 public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHandle: OmFileWriterBackend> {
     /// Store all byte offsets where our compressed chunks start. Later, we want to decompress chunk 1234 and know it starts at byte offset 5346545
     private var lookUpTable: [UInt64]
-    
+
     private var encoder: OmEncoder_t
-    
+
     /// Position of last chunk that has been written
     var chunkIndex: Int = 0
-    
+
     /// The scalefactor that is applied to all write data
     let scale_factor: Float
-    
+
     /// The offset that is applied to all write data
     let add_offset: Float
-    
+
     /// Type of compression and coding. E.g. delta, zigzag coding is then implemented in different compression routines
     let compression: CompressionType
-    
+
     /// The dimensions of the file
     let dimensions: [UInt64]
-    
+
     /// How the dimensions are chunked
     let chunks: [UInt64]
-    
+
     let compressedChunkBufferSize: UInt64
-    
+
     let chunkBuffer: UnsafeMutableRawBufferPointer
-    
+
     /// Temporarily write data here. Keeps also track of `totalBytesWritten`
     let buffer: OmBufferedWriter<FileHandle>
-    
-    
+
+
     public init(dimensions: [UInt64], chunkDimensions: [UInt64], compression: CompressionType, scale_factor: Float, add_offset: Float, buffer: OmBufferedWriter<FileHandle>) throws {
 
         assert(dimensions.count == chunkDimensions.count)
-        
+
         self.chunks = chunkDimensions
         self.dimensions = dimensions
         self.compression = compression
         self.scale_factor = scale_factor
         self.add_offset = add_offset
-        
+
         // Note: The encoder keeps the pointer to `&self.dimensions`. It is important that this array is not deallocated!
         self.encoder = OmEncoder_t()
         let error = om_encoder_init(&encoder, scale_factor, add_offset, compression.toC(), OmType.dataTypeArray.toC(), &self.dimensions, &self.chunks, UInt64(dimensions.count))
-        
+
         guard error == ERROR_OK else {
             throw OmFileFormatSwiftError.omEncoder(error: String(cString: om_error_string(error)))
         }
 
         /// Number of total chunks in the compressed files
         let nChunks = om_encoder_count_chunks(&encoder)
-        
+
         /// This is the minimum output buffer size for each compressed size. In practice the buffer should be much larger.
         self.compressedChunkBufferSize = om_encoder_compressed_chunk_buffer_size(&encoder)
-        
+
         let chunkBufferSize = om_encoder_chunk_buffer_size(&encoder)
-        
+
         /// Each thread needs its own chunk buffer to compress data. This implementation is single threaded
         self.chunkBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: Int(chunkBufferSize), alignment: 1)
         chunkBuffer.initializeMemory(as: UInt8.self, repeating: 0)
-        
+
         /// Allocate space for a lookup table. Needs to be number_of_chunks+1 to store start address and for each chunk then end address
         self.lookUpTable = .init(repeating: 0, count: Int(nChunks) + 1)
-        
+
         self.buffer = buffer
     }
-    
+
     /// Compress data and write it to file. Can be all, a single or multiple chunks. If multiple chunks are given at once, they must align with chunks.
     /// `arrayDimensions` specify the total dimensions of the input array
     /// `arrayRead` specify which parts of this array should be read
@@ -168,7 +192,7 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
             try writeData(pointer: array, arrayDimensions: arrayDimensions, arrayOffset: arrayOffset, arrayCount: arrayCount)
         }
     }
-    
+
     /// Compress data and write it to file. Can be all, a single or multiple chunks. If multiple chunks are given at once, they must align with chunks.
     /// `arrayDimensions` specify the total dimensions of the input array
     /// `arrayRead` specify which parts of this array should be read
@@ -177,28 +201,28 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
         let arrayDimensions = arrayDimensions ?? self.dimensions
         let arrayCount = arrayCount ?? arrayDimensions
         let arrayOffset = arrayOffset ?? [UInt64](repeating: 0, count: arrayDimensions.count)
-        
+
         assert(pointer.count == arrayDimensions.reduce(1, *))
         assert(arrayDimensions.allSatisfy({$0 >= 0}))
         assert(arrayOffset.allSatisfy({$0 >= 0}))
         assert(zip(arrayDimensions, zip(arrayOffset, arrayCount)).allSatisfy { $1.0 + $1.1 <= $0 })
-        
+
         /// For performance the output buffer should be able to hold a multiple of the chunk buffer size
         try buffer.reallocate(minimumCapacity: Int(compressedChunkBufferSize) * 4)
-        
+
         /// How many chunks can be written to the output. This could be only a single one, or multiple
         let numberOfChunksInArray = om_encoder_count_chunks_in_array(&encoder, arrayCount)
-        
+
         /// Store data start address if this is the first time this read is called
         if chunkIndex == 0 {
             lookUpTable[chunkIndex] = UInt64(buffer.totalBytesWritten)
         }
-        
+
         // This loop could be done in parallel. However, the order of chunks must remain the same in the LUT and final output buffer.
         // For multithreading, multiple buffers are required that need to be copied into the final buffer afterwards
         for chunkIndexOffsetInThisArray in 0..<numberOfChunksInArray {
             try buffer.reallocate(minimumCapacity: Int(compressedChunkBufferSize))
-            
+
             let bytes_written = om_encoder_compress_chunk(
                 &encoder,
                 pointer.baseAddress,
@@ -212,21 +236,21 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
             )
 
             buffer.incrementWritePosition(by: Int(bytes_written))
-            
+
             // Store chunk offset in LUT
             lookUpTable[chunkIndex+1] = UInt64(buffer.totalBytesWritten)
             chunkIndex += 1
         }
     }
-    
+
     /// Compress the lookup table and write it to the output buffer
     public func finalise() throws -> OmFileWriterArrayFinalised {
         let lut_offset = buffer.totalBytesWritten
-        
+
         /// The size of the total compressed LUT including some padding
         let buffer_size = om_encoder_lut_buffer_size(lookUpTable, UInt64(lookUpTable.count))
         try buffer.reallocate(minimumCapacity: Int(buffer_size))
-        
+
         /// Compress the LUT and return the actual compressed LUT size
         let compressed_lut_size = om_encoder_compress_lut(lookUpTable, UInt64(lookUpTable.count), buffer.bufferAtWritePosition, buffer_size)
         buffer.incrementWritePosition(by: Int(compressed_lut_size))
@@ -241,7 +265,7 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
             lutOffset: UInt64(lut_offset)
         )
     }
-    
+
     deinit {
         chunkBuffer.deallocate()
     }
@@ -251,23 +275,23 @@ public final class OmFileWriterArray<OmType: OmFileArrayDataTypeProtocol, FileHa
 public struct OmFileWriterArrayFinalised {
     /// The scale-factor that is applied to all write data
     let scale_factor: Float
-    
+
     /// The offset that is applied to all write data
     let add_offset: Float
-    
+
     /// Type of compression and coding. E.g. delta, zigzag coding is then implemented in different compression routines
     let compression: CompressionType
-    
+
     let datatype: DataType
-    
+
     /// The dimensions of the file
     let dimensions: [UInt64]
-    
+
     /// How the dimensions are chunked
     let chunks: [UInt64]
-    
+
     let lutSize: UInt64
-    
+
     let lutOffset: UInt64
 }
 
@@ -275,7 +299,7 @@ public struct OmFileWriterArrayFinalised {
 public struct OmOffsetSize {
     let offset: UInt64
     let size: UInt64
-    
+
     init(offset: UInt64, size: UInt64) {
         self.offset = offset
         self.size = size

--- a/Swift/OmFileFormat/OmFileWriter.swift
+++ b/Swift/OmFileFormat/OmFileWriter.swift
@@ -37,10 +37,10 @@ public struct OmFileWriter<FileHandle: OmFileWriterBackend> {
             let type = OmType.dataTypeScalar.toC()
             try buffer.alignTo64Bytes()
 
-            let stringLength: UInt16
+            let stringLength: UInt64
             if type == DATA_TYPE_STRING {
                 // For strings, pass the string length
-                stringLength = UInt16((value as! String).utf8.count) // TODO: safely init?
+                stringLength = UInt64((value as! String).utf8.count) // TODO: safely init?
             } else {
                 stringLength = 0
             }

--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -37,7 +37,7 @@ import Foundation
 
     @Test func variable() {
         var name: String = "name"
-        let stringSize: UInt16 = 0
+        let stringSize: UInt64 = 0
         name.withUTF8({ name in
             let sizeScalar = om_variable_write_scalar_size(UInt16(name.count), 0, DATA_TYPE_INT8, stringSize)
             #expect(sizeScalar == 13)
@@ -59,10 +59,10 @@ import Foundation
     @Test func variableString() {
         var name: String = "name"
         let value: String = "Hello, World!"
-        let stringSize = UInt16(value.utf8.count)
+        let stringSize = UInt64(value.utf8.count)
         name.withUTF8({ name in
             let sizeScalar = om_variable_write_scalar_size(UInt16(name.count), 0, DATA_TYPE_STRING, stringSize)
-            #expect(sizeScalar == 27)
+            #expect(sizeScalar == 33)
 
             var data = [UInt8](repeating: 255, count: sizeScalar)
 
@@ -75,7 +75,7 @@ import Foundation
                 4, // OmCompression_t: 4 = COMPRESSION_NONE
                 4, 0, // Size of name
                 0, 0, 0, 0, // Children count
-                13, 0, // stringSize
+                13, 0, 0, 0, 0, 0, 0, 0, // stringSize
                 72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33, // "Hello, World!"
                 110, 97, 109, 101 // "name"
             ])
@@ -298,7 +298,7 @@ import Foundation
         }
 
         // Ensure written bytes are correct
-        #expect(readFn.count == 288)
+        #expect(readFn.count == 296)
         let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{UInt8($0)}
         #expect(bytes[0..<3] == [79, 77, 3])
         #expect(bytes[3..<8] == [0, 3, 34, 140, 2]) // chunk
@@ -313,9 +313,9 @@ import Foundation
         #expect(bytes[35..<40] == [0, 0, 0, 0, 0]) // zero padding
         #expect(bytes[40..<40+17] == [5, 4, 5, 0, 0, 0, 0, 0, 82, 9, 188, 0, 105, 110, 116, 51, 50]) // scalar int32
         #expect(bytes[65..<65+22] == [4, 6, 0, 0, 0, 0, 0, 0, 0, 0, 64, 42, 129, 103, 65, 100, 111, 117, 98, 108, 101, 0]) // scalar double
-        #expect(bytes[88..<88+28] == [11, 4, 6, 0, 0, 0, 0, 0, 12, 0, 109, 121, 95, 97, 116, 116, 114, 105, 98, 117, 116, 101, 115, 116, 114, 105, 110, 103]) // scalar string
-        #expect(bytes[120..<120+140] == [20, 0, 4, 0, 3, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97]) // array meta // array meta
-        #expect(bytes[264..<288] == [79, 77, 3, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, 140, 0, 0, 0, 0, 0, 0, 0]) // trailer
+        #expect(bytes[88..<88+34] == [11, 4, 6, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 109, 121, 95, 97, 116, 116, 114, 105, 98, 117, 116, 101, 115, 116, 114, 105, 110, 103]) // scalar string
+        #expect(bytes[128..<128+140] == [20, 0, 4, 0, 3, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97]) // array meta
+        #expect(bytes[272..<296] == [79, 77, 3, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 140, 0, 0, 0, 0, 0, 0, 0]) // trailer
 
         // Test interpolation
         #expect(try read.readInterpolated(dim0X: 0, dim0XFraction: 0.5, dim0Y: 0, dim0YFraction: 0.5, dim0Nx: 3, dim1: 0..<3) == [6.0, 7.0, 8.0])

--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -359,7 +359,7 @@ import Foundation
         try fileWriter.writeTrailer(rootVariable: variable)
 
         let readFn = try MmapFile(fn: FileHandle.openFileReading(file: file))
-        #expect(readFn.count == 328)
+        #expect(readFn.count == 296)
         let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{ UInt8($0) }
         #expect(bytes[0..<3] == [79, 77, 3])
         #expect(bytes[3..<3+7] == [115, 116, 114, 105, 110, 103, 49]) // string1
@@ -389,21 +389,17 @@ import Foundation
             94, 0, 0, 0, 0, 0, 0, 0,
             102, 0, 0, 0, 0, 0, 0, 0
         ]) // LUT
-        #expect(bytes[104+13*8..<104+13*8+92] == [
+        #expect(bytes[104+13*8..<104+13*8+60] == [
             22, 4, 4, 0, 0, 0, 0, 0, // data type (1), compression (1), size of name (2), number of children (4)
             104, 0, 0, 0, 0, 0, 0, 0, // size of LUT
             104, 0, 0, 0, 0, 0, 0, 0, // offset of LUT
             3, 0, 0, 0, 0, 0, 0, 0, // number of dimensions
-            0, 0, 0, 0, 0, 0, 0, 0, // scale factor (4) and add offset (4), could be removed for string arrays
             3, 0, 0, 0, 0, 0, 0, 0, // dimension1
             2, 0, 0, 0, 0, 0, 0, 0, // dimension2
             2, 0, 0, 0, 0, 0, 0, 0, // dimension3
-            1, 0, 0, 0, 0, 0, 0, 0, // chunk1, should be removed
-            1, 0, 0, 0, 0, 0, 0, 0, // chunk2, should be removed
-            1, 0, 0, 0, 0, 0, 0, 0, // chunk3, should be removed
             100, 97, 116, 97
         ]) // array meta
-        #expect(bytes[328-24..<328] == [79, 77, 3, 0, 0, 0, 0, 0, 208, 0, 0, 0, 0, 0, 0, 0, 92, 0, 0, 0, 0, 0, 0, 0]) // trailer
+        #expect(bytes[296-24..<296] == [79, 77, 3, 0, 0, 0, 0, 0, 208, 0, 0, 0, 0, 0, 0, 0, 60, 0, 0, 0, 0, 0, 0, 0]) // trailer
 
 
         let read = try OmFileReader(fn: readFn).asStringArray()!

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -118,6 +118,9 @@ void om_common_copy16(uint64_t length, float scale_factor, float add_offset, con
 void om_common_copy32(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
 void om_common_copy64(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
 
+/// Copy string array
+void om_common_copy_string_array(uint64_t length, const void* src, void* dst);
+
 uint64_t om_common_compress_fpxenc32(const void* src, uint64_t length, void* dst);
 uint64_t om_common_compress_fpxenc64(const void* src, uint64_t length, void* dst);
 uint64_t om_common_decompress_fpxdec32(const void* src, uint64_t length, void* dst);

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -66,7 +66,8 @@ typedef enum {
     COMPRESSION_FPX_XOR2D = 1, // Lossless float/double compression using 2D xor coding.
     COMPRESSION_PFOR_DELTA2D = 2, // PFor integer compression. Floating point values are scaled to 32 bit signed integers. Doubles are scaled to 64 bit signed integers.
     COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC = 3, // Similar to `COMPRESSION_PFOR_DELTA2D_INT16` but applies `log10(1+x)` before.
-    COMPRESSION_NONE = 4
+    COMPRESSION_NONE = 4,
+    COMPRESSION_LZ4 = 5,
 } OmCompression_t;
 
 /// Get the number of bytes per element.

--- a/c/include/om_variable.h
+++ b/c/include/om_variable.h
@@ -21,7 +21,7 @@
 typedef struct {
     uint8_t data_type; // OmDataType_t
     uint8_t compression_type; // OmCompression_t
-    uint16_t name_size; // maximum 65k name strings
+    uint16_t name_size; // maximum 65k characters in name strings
     uint32_t children_count;
 
     // Followed by payload
@@ -30,7 +30,7 @@ typedef struct {
 
     // Scalars are now set
     //void* value;
-    
+
     // name is always last
     //char[name_size] name;
 } OmVariableV3_t;
@@ -38,23 +38,23 @@ typedef struct {
 typedef struct {
     uint8_t data_type; // OmDataType_t
     uint8_t compression_type; // OmCompression_t
-    uint16_t name_size; // maximum 65k name strings
+    uint16_t name_size; // maximum 65k characters in name strings
     uint32_t children_count;
     uint64_t lut_size;
     uint64_t lut_offset;
     uint64_t dimension_count;
-    
+
     float scale_factor;
     float add_offset;
-    
+
     // Followed by payload: NOTE: Lets to try 64 bit align it somehow
     //uint32_t[children_count] children_length;
     //uint32_t[children_count] children_offset;
-    
+
     // Afterwards additional payload from value types
     //uint64_t[dimension_count] dimensions;
     //uint64_t[dimension_count] chunks;
-    
+
     // name is always last
     //char[name_size] name;
 } OmVariableArrayV3_t;
@@ -62,7 +62,7 @@ typedef struct {
 typedef struct {
     uint8_t data_type; // OmDataType_t
     uint8_t compression_type; // OmCompression_t
-    uint16_t name_size; // maximum 65k name strings
+    uint16_t name_size; // maximum 65k characters in name strings
     uint32_t children_count;
     uint64_t string_size;
     // followed by the string value
@@ -122,16 +122,25 @@ bool om_variable_get_children(const OmVariable_t* variable, uint32_t children_of
 /// Read a variable as a scalar
 OmError_t om_variable_get_scalar(const OmVariable_t* variable, void* value);
 
+/// Read a variable as a string
+OmString_t om_variable_get_string(const OmVariable_t* variable);
+
 
 
 
 /// =========== Functions for writing ===============
 
-/// Get the length of a scalar variable if written to a file
-size_t om_variable_write_scalar_size(uint16_t name_size, uint32_t children_count, OmDataType_t data_type);
+/// Get the length of a scalar variable if written to a file.
+/// If the scalar is a string, we need to know the length of the string.
+size_t om_variable_write_scalar_size(uint16_t name_size, uint32_t children_count, OmDataType_t data_type, uint16_t string_length);
+
+/// Get the length of a string variable if written to a file.
+// size_t om_variable_write_string_size(uint16_t name_size, uint32_t children_count, uint16_t string_length);
 
 /// Write a scalar variable with name and children variables
-void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, OmDataType_t data_type, const void* value);
+void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, OmDataType_t data_type, const void* value, uint16_t string_length);
+
+// void om_variable_write_string(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, const char* value, uint16_t string_length);
 
 /// Get the size of meta attributes of a numeric array if written to a file. Does not contain any data. Only offsets for the actual data.
 size_t om_variable_write_numeric_array_size(uint16_t name_size, uint32_t children_count, uint64_t dimension_count);

--- a/c/include/om_variable.h
+++ b/c/include/om_variable.h
@@ -132,15 +132,15 @@ OmString_t om_variable_get_string(const OmVariable_t* variable);
 
 /// Get the length of a scalar variable if written to a file.
 /// If the scalar is a string, we need to know the length of the string.
-size_t om_variable_write_scalar_size(uint16_t name_size, uint32_t children_count, OmDataType_t data_type, uint16_t string_length);
+size_t om_variable_write_scalar_size(uint16_t name_size, uint32_t children_count, OmDataType_t data_type, uint64_t string_length);
 
 /// Get the length of a string variable if written to a file.
-// size_t om_variable_write_string_size(uint16_t name_size, uint32_t children_count, uint16_t string_length);
+// size_t om_variable_write_string_size(uint16_t name_size, uint32_t children_count, uint64_t string_length);
 
 /// Write a scalar variable with name and children variables
-void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, OmDataType_t data_type, const void* value, uint16_t string_length);
+void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, OmDataType_t data_type, const void* value, uint64_t string_length);
 
-// void om_variable_write_string(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, const char* value, uint16_t string_length);
+// void om_variable_write_string(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, const char* value, uint64_t string_length);
 
 /// Get the size of meta attributes of a numeric array if written to a file. Does not contain any data. Only offsets for the actual data.
 size_t om_variable_write_numeric_array_size(uint16_t name_size, uint32_t children_count, uint64_t dimension_count);

--- a/c/include/om_variable.h
+++ b/c/include/om_variable.h
@@ -11,11 +11,6 @@
 #include "om_common.h"
 #include "om_file.h"
 
-/**
- TODO:
- - String and String array support
- */
-
 /// =========== Structures describing the data layout ===============
 
 typedef struct {
@@ -25,14 +20,14 @@ typedef struct {
     uint32_t children_count;
 
     // Followed by payload
-    //uint32_t[children_count] children_length;
-    //uint32_t[children_count] children_offset;
+    // uint32_t[children_count] children_length;
+    // uint32_t[children_count] children_offset;
 
     // Scalars are now set
-    //void* value;
+    // void* value;
 
-    // name is always last
-    //char[name_size] name;
+    // Name is always last
+    // char[name_size] name;
 } OmVariableV3_t;
 
 typedef struct {
@@ -48,16 +43,36 @@ typedef struct {
     float add_offset;
 
     // Followed by payload: NOTE: Lets to try 64 bit align it somehow
-    //uint32_t[children_count] children_length;
-    //uint32_t[children_count] children_offset;
+    // uint32_t[children_count] children_length;
+    // uint32_t[children_count] children_offset;
 
     // Afterwards additional payload from value types
-    //uint64_t[dimension_count] dimensions;
-    //uint64_t[dimension_count] chunks;
+    // uint64_t[dimension_count] dimensions;
+    // uint64_t[dimension_count] chunks;
 
-    // name is always last
-    //char[name_size] name;
+    // Name is always last
+    // char[name_size] name;
 } OmVariableArrayV3_t;
+
+typedef struct {
+    uint8_t data_type; // OmDataType_t
+    uint8_t compression_type; // OmCompression_t
+    uint16_t name_size; // maximum 65k characters in name strings
+    uint32_t children_count;
+    uint64_t lut_size;
+    uint64_t lut_offset;
+    uint64_t dimension_count;
+
+    // Followed by payload: NOTE: Lets to try 64 bit align it somehow
+    // uint32_t[children_count] children_length;
+    // uint32_t[children_count] children_offset;
+
+    // Afterwards additional payload from value types
+    // uint64_t[dimension_count] dimensions;
+
+    // Name is always last
+    // char[name_size] name;
+} OmVariableStringArrayV3_t;
 
 typedef struct {
     uint8_t data_type; // OmDataType_t
@@ -146,7 +161,42 @@ void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_c
 size_t om_variable_write_numeric_array_size(uint16_t name_size, uint32_t children_count, uint64_t dimension_count);
 
 /// Write meta data for a numeric array to file
-void om_variable_write_numeric_array(void* dst, uint16_t name_size, uint32_t children_count, const uint64_t* children_offsets, const uint64_t* children_sizes, const char* name, OmDataType_t data_type, OmCompression_t compression_type, float scale_factor, float add_offset, uint64_t dimension_count, const uint64_t *dimensions, const uint64_t *chunks, uint64_t lut_size, uint64_t lut_offset);
+void om_variable_write_numeric_array(
+    void* dst,
+    uint16_t name_size,
+    uint32_t children_count,
+    const uint64_t* children_offsets,
+    const uint64_t* children_sizes,
+    const char* name,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
+    float scale_factor,
+    float add_offset,
+    uint64_t dimension_count,
+    const uint64_t *dimensions,
+    const uint64_t *chunks,
+    uint64_t lut_size,
+    uint64_t lut_offset
+);
+
+/// Get the size of meta attributes of a string array if written to a file. Does not contain any data. Only offsets for the actual data.
+size_t om_variable_write_string_array_size(uint16_t name_size, uint32_t children_count, uint64_t dimension_count);
+
+/// Write meta data for a string array to file
+void om_variable_write_string_array(
+    void* dst,
+    uint16_t name_size,
+    uint32_t children_count,
+    const uint64_t* children_offsets,
+    const uint64_t* children_sizes,
+    const char* name,
+    OmDataType_t data_type,
+    OmCompression_t compression_type,
+    uint64_t dimension_count,
+    const uint64_t *dimensions,
+    uint64_t lut_size,
+    uint64_t lut_offset
+);
 
 
 

--- a/c/include/om_variable.h
+++ b/c/include/om_variable.h
@@ -158,7 +158,7 @@ typedef enum {
     OM_MEMORY_LAYOUT_ARRAY = 1,
     OM_MEMORY_LAYOUT_SCALAR = 3,
     //OM_MEMORY_LAYOUT_STRING = 4,
-    //OM_MEMORY_LAYOUT_STRING_ARRAY = 5,
+    OM_MEMORY_LAYOUT_STRING_ARRAY = 5,
 } OmMemoryLayout_t;
 
 /// Check if a variable is legacy or version 3 array of scalar. Legacy files are the entire header containing magic number and version.

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -63,9 +63,7 @@ uint8_t om_get_bytes_per_element(OmDataType_t data_type, OmError_t* error) {
             return 8;
 
         case DATA_TYPE_STRING_ARRAY:
-            // NOTE: STRING_ARRAY is currently not implemented!
-            *error = ERROR_INVALID_DATA_TYPE;
-            return 0;
+            return 0; // strings are variable length
             break;
 
         case DATA_TYPE_INT8:
@@ -105,7 +103,8 @@ uint8_t om_get_bytes_per_element_compressed(OmDataType_t data_type, OmCompressio
             return om_get_bytes_per_element(data_type, error);
         case COMPRESSION_PFOR_DELTA2D:
             return om_get_bytes_per_element(data_type, error);
-
+        case COMPRESSION_NONE:
+            return 0;
         default:
             *error = ERROR_INVALID_COMPRESSION_TYPE;
     }
@@ -213,6 +212,12 @@ void om_common_copy32(uint64_t length, float scale_factor, float add_offset, con
 void om_common_copy64(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst) {
     for (uint64_t i = 0; i < length; ++i) {
         ((int64_t *)dst)[i] = ((int64_t *)src)[i];
+    }
+}
+
+void om_common_copy_string_array(uint64_t length, const void* src, void* dst) {
+    for (uint64_t i = 0; i < length; ++i) {
+        ((char **)dst)[i] = ((char **)src)[i];
     }
 }
 

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -63,8 +63,9 @@ uint8_t om_get_bytes_per_element(OmDataType_t data_type, OmError_t* error) {
             return 8;
 
         case DATA_TYPE_STRING_ARRAY:
-            return 0; // strings are variable length
-            break;
+        // NOTE: Strings are variable length and should not be used with this function!
+            *error = ERROR_INVALID_DATA_TYPE;
+            return 0;
 
         case DATA_TYPE_INT8:
         case DATA_TYPE_UINT8:

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -11,6 +11,7 @@
 #include "conf.h"
 #include "delta2d.h"
 #include "om_decoder.h"
+#include "lz4.h"
 
 #pragma clang diagnostic error "-Wswitch"
 
@@ -201,6 +202,9 @@ ALWAYS_INLINE uint64_t om_decode_decompress(
                     break;
             }
             break;
+        case COMPRESSION_LZ4:
+            result = LZ4_decompress_safe((char*)input, (char*)output, (size_t)count, (int)1024); // FIXME: hardcoded output size
+            break;
     }
 
     return result;
@@ -253,6 +257,8 @@ ALWAYS_INLINE void om_decode_filter(
             break;
 
         case COMPRESSION_NONE:
+            break;
+        case COMPRESSION_LZ4:
             break;
     }
 }
@@ -315,6 +321,8 @@ ALWAYS_INLINE void om_decode_copy(
             }
             break;
         case COMPRESSION_NONE:
+            break;
+        case COMPRESSION_LZ4:
             break;
     }
 }

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -454,7 +454,7 @@ bool om_decoder_next_index_read(const OmDecoder_t* decoder, OmDecoder_indexRead_
 
     const uint64_t readStart = (index_read->nextChunk.lowerBound - alignOffset) / lut_chunk_element_count * lut_chunk_length;
 
-    while (1) {
+    while (true) {
         const uint64_t maxRead = io_size_max / lut_chunk_length * lut_chunk_element_count;
         const uint64_t nextChunkCount = index_read->nextChunk.upperBound - index_read->nextChunk.lowerBound;
         const uint64_t nextIncrement = max(1, min(maxRead-1, nextChunkCount - 1));

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -73,6 +73,7 @@ OmError_t om_decoder_init(
             lut_chunk_length = 1;
             break;
         }
+        case OM_MEMORY_LAYOUT_STRING_ARRAY:
         case OM_MEMORY_LAYOUT_SCALAR:
             return ERROR_INVALID_DATA_TYPE;
     }
@@ -184,24 +185,21 @@ ALWAYS_INLINE uint64_t om_decode_decompress(
                 case DATA_TYPE_DOUBLE_ARRAY:
                     result = p4nzdec64((unsigned char*)input, (size_t)count, (uint64_t*)output);
                     break;
-                case DATA_TYPE_NONE:
-                case DATA_TYPE_STRING:
-                case DATA_TYPE_STRING_ARRAY:
-                case DATA_TYPE_INT8:
-                case DATA_TYPE_UINT8:
-                case DATA_TYPE_INT16:
-                case DATA_TYPE_UINT16:
-                case DATA_TYPE_INT32:
-                case DATA_TYPE_UINT32:
-                case DATA_TYPE_INT64:
-                case DATA_TYPE_UINT64:
-                case DATA_TYPE_FLOAT:
-                case DATA_TYPE_DOUBLE:
+                default:
                     break;
             }
             break;
-
         case COMPRESSION_NONE:
+            switch (data_type) {
+                case DATA_TYPE_STRING_ARRAY:
+                    // For string arrays, we just return the total size
+                    // The actual string data is read separately
+                    result = count;
+                    break;
+                default:
+                    // Other data types need to be compressed
+                    break;
+            }
             break;
     }
 

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -124,6 +124,16 @@ ALWAYS_INLINE uint64_t om_encode_compress(
             break;
 
         case COMPRESSION_NONE:
+            switch (data_type) {
+                case DATA_TYPE_STRING_ARRAY:
+                    // For string arrays, we just return the string length
+                    // The actual string data follows immediately after
+                    result = count;
+                    break;
+                default:
+                    // Other data types need to be compressed
+                    break;
+            }
             break;
     }
 

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -11,6 +11,7 @@
 #include "fp.h"
 #include "delta2d.h"
 #include "conf.h"
+#include "lz4.h"
 
 #pragma clang diagnostic error "-Wswitch"
 
@@ -123,6 +124,10 @@ ALWAYS_INLINE uint64_t om_encode_compress(
             }
             break;
 
+        case COMPRESSION_LZ4:
+            result = LZ4_compress_default((const char*)input, (char*)output, (int)count, (int)1024); // FIXME: hardcoded output size
+            break;
+
         case COMPRESSION_NONE:
             switch (data_type) {
                 case DATA_TYPE_STRING_ARRAY:
@@ -190,6 +195,8 @@ ALWAYS_INLINE void om_encode_filter(
             break;
         case COMPRESSION_NONE:
             break;
+        case COMPRESSION_LZ4:
+            break;
     }
 }
 
@@ -252,6 +259,8 @@ ALWAYS_INLINE void om_encode_copy(
             break;
 
         case COMPRESSION_NONE:
+            break;
+        case COMPRESSION_LZ4:
             break;
     }
 }

--- a/c/src/om_variable.c
+++ b/c/src/om_variable.c
@@ -309,9 +309,9 @@ void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_c
             break;
         case DATA_TYPE_STRING:
             // Strings are written as uint16_t string_length + string data
-            *(uint16_t*)destValue = string_length;
+            *(uint16_t*)destValue = string_length; // write string length to the first two bytes
             for (uint16_t i = 0; i < string_length; i++) {
-                destValue[sizeof(uint16_t) + i] = ((const char*)value)[i];
+                ((char*)destValue)[sizeof(uint16_t) + i] = ((const char*)value)[i];
             }
 
             valueSize = sizeof(uint16_t) + string_length;

--- a/c/src/om_variable.c
+++ b/c/src/om_variable.c
@@ -6,7 +6,6 @@
 //
 
 #include "om_variable.h"
-#include <stdio.h>
 
 const OmVariable_t* om_variable_init(const void* src) {
     return src;
@@ -309,10 +308,8 @@ void om_variable_write_scalar(void* dst, uint16_t name_size, uint32_t children_c
             valueSize = 8;
             break;
         case DATA_TYPE_STRING:
-            // Write the string length
+            // Strings are written as uint16_t string_length + string data
             *(uint16_t*)destValue = string_length;
-
-            // Copy the string data
             for (uint16_t i = 0; i < string_length; i++) {
                 destValue[sizeof(uint16_t) + i] = ((const char*)value)[i];
             }


### PR DESCRIPTION
This is a POC how we could integrate lz4 (if desired). 
lz4 only adds very little to the binary size, e.g. 0.01 MB in the WASM build for typescript-omfiles (tested in https://github.com/open-meteo/typescript-omfiles/commit/002ae006f9ad00dbec92f79c09a2d8a1fd90fa50).

I only open this PR, so we will be able to find a reference more easily if we ever need it again.