### PR TITLE
fix: add offset

### DIFF
--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -829,7 +829,7 @@ import OmFileFormatC
                         chunkDimensions: chunkDimensions,
                         compression: .pfor_delta2d,
                         scale_factor: 10000,
-                        add_offset: 0
+                        add_offset: 1000
                     )
                     try writer.writeData(array: values)
                     let variableMeta = try writer.finalise()

--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -880,13 +880,13 @@ import OmFileFormatC
 
         ints.withUnsafeBufferPointer { srcPtr in
             floats.withUnsafeMutableBufferPointer { dstPtr in
-                om_common_copy_int16_to_float_log10(UInt64(ints.count), 1000.0, 0.0, srcPtr.baseAddress, dstPtr.baseAddress)
+                om_common_copy_int16_to_float_log10(UInt64(ints.count), 1000.0, srcPtr.baseAddress, dstPtr.baseAddress)
             }
         }
 
         floats.withUnsafeBufferPointer { srcPtr in
             intsRoundtrip.withUnsafeMutableBufferPointer { dstPtr in
-                om_common_copy_float_to_int16_log10(UInt64(floats.count), 1000.0, 0.0, srcPtr.baseAddress, dstPtr.baseAddress)
+                om_common_copy_float_to_int16_log10(UInt64(floats.count), 1000.0, srcPtr.baseAddress, dstPtr.baseAddress)
             }
         }
 

--- a/c/include/om_common.h
+++ b/c/include/om_common.h
@@ -103,7 +103,7 @@ void om_common_copy_float_to_int32(uint64_t length, float scale_factor, float ad
 void om_common_copy_double_to_int64(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
 
 /// Copy 16 bit integer array and convert to float and scale log10
-void om_common_copy_float_to_int16_log10(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
+void om_common_copy_float_to_int16_log10(uint64_t length, float scale_factor, const void* src, void* dst);
 
 /// Convert int16 and scale to float
 void om_common_copy_int16_to_float(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
@@ -111,7 +111,7 @@ void om_common_copy_int32_to_float(uint64_t length, float scale_factor, float ad
 void om_common_copy_int64_to_double(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
 
 /// Convert int16 and scale to float with log10
-void om_common_copy_int16_to_float_log10(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
+void om_common_copy_int16_to_float_log10(uint64_t length, float scale_factor, const void* src, void* dst);
 
 void om_common_copy8(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);
 void om_common_copy16(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst);

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -151,7 +151,7 @@ void om_common_copy_double_to_int64(uint64_t length, float scale_factor, float a
     }
 }
 
-void om_common_copy_float_to_int16_log10(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst) {
+void om_common_copy_float_to_int16_log10(uint64_t length, float scale_factor, const void* src, void* dst) {
     for (uint64_t i = 0; i < length; ++i) {
         float val = ((float *)src)[i];
         if (isnan(val)) {
@@ -185,7 +185,7 @@ void om_common_copy_int64_to_double(uint64_t length, float scale_factor, float a
     }
 }
 
-void om_common_copy_int16_to_float_log10(uint64_t length, float scale_factor, float add_offset, const void* src, void* dst) {
+void om_common_copy_int16_to_float_log10(uint64_t length, float scale_factor, const void* src, void* dst) {
     for (uint64_t i = 0; i < length; ++i) {
         int16_t val = ((int16_t *)src)[i];
         ((float *)dst)[i] = (val == INT16_MAX) ? NAN : powf(10, (float)val / scale_factor) - 1;

--- a/c/src/om_common.c
+++ b/c/src/om_common.c
@@ -118,7 +118,7 @@ void om_common_copy_float_to_int16(uint64_t length, float scale_factor, float ad
         if (isnan(val)) {
             ((int16_t *)dst)[i] = INT16_MAX;
         } else {
-            float scaled = val * scale_factor + add_offset;
+            float scaled = (val + add_offset) * scale_factor;
             float clamped = fmaxf(INT16_MIN, fminf(INT16_MAX, roundf(scaled)));
             ((int16_t *)dst)[i] = (int16_t)clamped;
         }
@@ -131,7 +131,7 @@ void om_common_copy_float_to_int32(uint64_t length, float scale_factor, float ad
         if (isnan(val)) {
             ((int32_t *)dst)[i] = INT32_MAX;
         } else {
-            float scaled = val * scale_factor + add_offset;
+            float scaled = (val + add_offset) * scale_factor;
             float clamped = fmaxf((float)INT32_MIN, fminf((float)INT32_MAX, roundf(scaled)));
             ((int32_t *)dst)[i] = (int32_t)clamped;
         }
@@ -144,7 +144,7 @@ void om_common_copy_double_to_int64(uint64_t length, float scale_factor, float a
         if (isnan(val)) {
             ((int64_t *)dst)[i] = INT64_MAX;
         } else {
-            double scaled = val * (double)scale_factor + (double)add_offset;
+            double scaled = (val + (double)add_offset) * (double)scale_factor;
             double clamped = fmax((double)INT64_MIN, fmin((double)INT64_MAX, round(scaled)));
             ((int64_t *)dst)[i] = (int64_t)clamped;
         }

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -276,7 +276,7 @@ ALWAYS_INLINE void om_decode_copy(
 
         case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
             assert(data_type == DATA_TYPE_FLOAT_ARRAY && "Expecting float array");
-            om_common_copy_int16_to_float_log10(count, scale_factor, add_offset, input, output);
+            om_common_copy_int16_to_float_log10(count, scale_factor, input, output);
             break;
 
         case COMPRESSION_FPX_XOR2D:

--- a/c/src/om_encoder.c
+++ b/c/src/om_encoder.c
@@ -200,7 +200,7 @@ ALWAYS_INLINE void om_encode_copy(
 
         case COMPRESSION_PFOR_DELTA2D_INT16_LOGARITHMIC:
             assert(data_type == DATA_TYPE_FLOAT_ARRAY && "Expecting float array");
-            om_common_copy_float_to_int16_log10(count, scale_factor, add_offset, input, output);
+            om_common_copy_float_to_int16_log10(count, scale_factor, input, output);
             break;
 
         case COMPRESSION_FPX_XOR2D:


### PR DESCRIPTION
Offset coding was not correctly implemented and unfortunately that was not caught by a test case. 

I also removed the add_offset parameter from the log10 based functions, because it only adds confusion to the function signatures.