### PR TITLE
fix: Only use scalar return variables for WASM integration

### DIFF
--- a/Swift/OmFileFormat/OmFileReader.swift
+++ b/Swift/OmFileFormat/OmFileReader.swift
@@ -65,11 +65,12 @@ public struct OmFileReader<Backend: OmFileReaderBackend>: OmFileReaderProtocol {
     public func getName() -> String? {
         return variable.withUnsafeBytes({
             let variable = om_variable_init($0.baseAddress)
-            let name = om_variable_get_name(variable);
-            guard name.size > 0 else {
+            var length: UInt16 = 0
+            let name = om_variable_get_name(variable, &length);
+            guard let name, length > 0 else {
                 return nil
             }
-            let buffer = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: name.value), count: Int(name.size), deallocator: .none)
+            let buffer = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: name), count: Int(length), deallocator: .none)
             return String(data: buffer, encoding: .utf8)
         })
     }

--- a/Swift/OmFileFormat/OmFileReaderArray.swift
+++ b/Swift/OmFileFormat/OmFileReaderArray.swift
@@ -38,8 +38,9 @@ public struct OmFileReaderArray<Backend: OmFileReaderBackend, OmType: OmFileArra
     public func withDimensions<R>(_ body: (_: UnsafeBufferPointer<UInt64>) -> R) -> R {
         return variable.withUnsafeBytes({
             let variable = om_variable_init($0.baseAddress)
+            let count = om_variable_get_dimensions_count(variable)
             let dimensions = om_variable_get_dimensions(variable)
-            return body(UnsafeBufferPointer<UInt64>(start: dimensions.values, count: Int(dimensions.count)))
+            return body(UnsafeBufferPointer<UInt64>(start: dimensions, count: Int(count)))
         })
     }
 
@@ -47,8 +48,9 @@ public struct OmFileReaderArray<Backend: OmFileReaderBackend, OmType: OmFileArra
     public func withChunkDimensions<R>(_ body: (_: UnsafeBufferPointer<UInt64>) -> R) -> R {
         return variable.withUnsafeBytes({
             let variable = om_variable_init($0.baseAddress)
+            let count = om_variable_get_dimensions_count(variable)
             let dimensions = om_variable_get_chunks(variable)
-            return body(UnsafeBufferPointer<UInt64>(start: dimensions.values, count: Int(dimensions.count)))
+            return body(UnsafeBufferPointer<UInt64>(start: dimensions, count: Int(count)))
         })
     }
 

--- a/c/include/om_variable.h
+++ b/c/include/om_variable.h
@@ -67,22 +67,11 @@ typedef void* OmVariable_t;
 /// =========== Functions for reading ===============
 
 
-typedef struct {
-    const uint16_t size;
-    const char* value;
-} OmString_t;
-
-typedef struct {
-    const uint64_t count;
-    const uint64_t* values;
-} OmDimensions_t;
-
-
 /// After reading data for the variable, initialize it. This is literally a simple cast to an opaque pointer. Source memory must remain accessible!
 const OmVariable_t* om_variable_init(const void* src);
 
-/// Get the name of of a given variable. No guarantee for zero termination!
-OmString_t om_variable_get_name(const OmVariable_t* variable);
+/// Get the name of of a given variable. No guarantee for zero termination! The length in bytes of the string is placed into `length`.
+const char* om_variable_get_name(const OmVariable_t* variable, uint16_t* length);
 
 /// Get the type of the current variable
 OmDataType_t om_variable_get_type(const OmVariable_t* variable);
@@ -94,11 +83,14 @@ float om_variable_get_scale_factor(const OmVariable_t* variable);
 
 float om_variable_get_add_offset(const OmVariable_t* variable);
 
+/// Get number of dimensions
+uint64_t om_variable_get_dimensions_count(const OmVariable_t* variable);
+
 /// Get a pointer to the dimensions of a OM variable
-OmDimensions_t om_variable_get_dimensions(const OmVariable_t* variable);
+const uint64_t* om_variable_get_dimensions(const OmVariable_t* variable);
 
 /// Get a pointer to the chunk dimensions of an OM Variable
-OmDimensions_t om_variable_get_chunks(const OmVariable_t* variable);
+const uint64_t* om_variable_get_chunks(const OmVariable_t* variable);
 
 /// Return how many children are available for a given variable
 uint32_t om_variable_get_children_count(const OmVariable_t* variable);

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -68,8 +68,8 @@ OmError_t om_decoder_init(
             compression = metaV3->compression_type;
             lut_size = metaV3->lut_size;
             lut_start = metaV3->lut_offset;
-            dimensions = om_variable_get_dimensions(variable).values;
-            chunks = om_variable_get_chunks(variable).values;
+            dimensions = om_variable_get_dimensions(variable);
+            chunks = om_variable_get_chunks(variable);
             lut_chunk_length = 1;
             break;
         }


### PR DESCRIPTION
Remove dimensions_t and string_t. Only use scalar return types for better WASM integration