### PR TITLE
fix(rust): default to non native build

### DIFF
--- a/rust/om-file-format-sys/build.rs
+++ b/rust/om-file-format-sys/build.rs
@@ -59,7 +59,7 @@ fn configure_build_flags(build: &mut cc::Build, config: &BuildConfig, compiler: 
             if config.is_windows && compiler.is_like_msvc() {
                 // No special flags needed for MSVC atm
             } else {
-                // Choose between skylake and native based on environment variable
+                // x86-64-v3 has AVX2 (2013 Haswell Architecture) and should be a safe and performant baseline
                 if !config.native_build {
                     build.flag("-march=x86-64-v3");
                 } else {


### PR DESCRIPTION
Native builds were causing flaky behaviour in tests in python-omfiles, e.g. https://github.com/open-meteo/python-omfiles/actions/runs/20928830841/job/60134468000