### PR TITLE
fix: double-precision XOR delta encoding using wrong pointer width + bool return cleanup

### DIFF
--- a/c/src/delta2d.c
+++ b/c/src/delta2d.c
@@ -116,7 +116,7 @@ void delta2d_decode_xor_double(const size_t length0, const size_t length1, doubl
     if (length0 <= 1) {
         return;
     }
-    int* chunkBufferInt = (int*)chunkBuffer;
+    uint64_t* chunkBufferInt = (uint64_t*)chunkBuffer;
     for (size_t d0 = 1; d0 < length0; d0++) {
         for (size_t d1 = 0; d1 < length1; d1++) {
             chunkBufferInt[d0*length1 + d1] ^= chunkBufferInt[(d0-1)*length1 + d1];
@@ -128,7 +128,7 @@ void delta2d_encode_xor_double(const size_t length0, const size_t length1, doubl
     if (length0 <= 1) {
         return;
     }
-    int* chunkBufferInt = (int*)chunkBuffer;
+    uint64_t* chunkBufferInt = (uint64_t*)chunkBuffer;
     for (size_t d0 = length0-1; d0 >= 1; d0--) {
         for (size_t d1 = 0; d1 < length1; d1++) {
             chunkBufferInt[d0*length1 + d1] ^= chunkBufferInt[(d0-1)*length1 + d1];

--- a/c/src/om_decoder.c
+++ b/c/src/om_decoder.c
@@ -841,5 +841,5 @@ bool om_decoder_decode_chunks(const OmDecoder_t *decoder, OmRange_t chunk, const
         (*error) = ERROR_DEFLATED_SIZE_MISMATCH;
         return false;
     }
-    return pos;
+    return true;
 }


### PR DESCRIPTION
Two small fixes:

1. delta2d.c - delta2d_encode_xor_double and delta2d_decode_xor_double were casting double* to int* (32-bit) instead of uint64_t* (64-bit). This meant only the lower half of each double got XOR-delta'd, silently corrupting any double-precision data compressed with COMPRESSION_FPX_XOR2D. Float path was fine because float and int are both 4 bytes.

2. om_decoder.c - om_decoder_decode_chunks returned a uint64_t byte count (pos) from a bool function instead of true/false. Worked by accident since pos is always >0 on success, but wrong.